### PR TITLE
switched to ruff and fixed pyproject.toml name

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install ruff 
         pip install -r requirements.txt
         pip install -r requirements-test.txt
-    - name: Analysing the code with pylint
+    - name: Analysing the code with ruff 
       run: |
-        python -m pylint $(git ls-files 'pyspinw/*.py')
+        ruff check pyspinw/ 

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,0 @@
-[FORMAT]
-max-line-length=120
-
-[MESSAGES CONTROL]
-disable=fixme, R

--- a/pypackage.toml
+++ b/pypackage.toml
@@ -1,8 +1,0 @@
-# TODO: Fill this out fully
-
-[project]
-name = "PySpinW"
-dynamic = ["version"]
-
-[tool.setuptools.dynamic]
-version = {attr = "pyspinw.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+# TODO: Fill this out fully
+
+[project]
+name = "PySpinW"
+dynamic = ["version"]
+
+[tool.setuptools.dynamic]
+version = {attr = "pyspinw.__version__"}
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["PL"]
+ignore = ["PLR"]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
-pylint
+ruff
 pytest


### PR DESCRIPTION
This PR changes Pylint for Ruff (with the same rulesets for now). You can run the linter with automatic fixes by `ruff check --fix`.

This also renames `pypackage.toml` (typo) to `pyproject.toml`.