### PR TITLE
Refactors spin-wave calculation for parallelism

### DIFF
--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -1,5 +1,6 @@
 """Spinwave Calculations"""
 
+import multiprocessing
 from concurrent.futures import wait, ProcessPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
@@ -9,7 +10,7 @@ from scipy.linalg import ldl
 
 from pyspinw.checks import check_sizes
 
-PARALLEL = False
+PARALLEL = True
 
 
 # Disable linting for bad variable names, because they should match the docs
@@ -68,84 +69,95 @@ def spinwave_calculation(rotations: list[np.ndarray],
     C *= 2
 
     if PARALLEL:
+        # Linear algebra routines in numpy are already parallelised and usually use 4 cores
+        # for a single process, so we want to reduce contention by using fewer processes.
+        n_proc = int(np.floor(multiprocessing.cpu_count() / 4))
         with ProcessPoolExecutor() as executor:
-            q_calculations = [executor.submit(_calc_single_q, q, C, n_sites, z, spin_coefficients, couplings)
-                              for q in q_vectors]
+            q_calculations = [executor.submit(_calc_q_chunks, q, C, n_sites, z, spin_coefficients, couplings)
+                              for q in _get_q_chunks(q_vectors, n_proc)]
         wait(q_calculations)
-        energies = [future.result() for future in q_calculations]
+        energies = np.concat(tuple(future.result() for future in q_calculations))
     else:
-        energies = [_calc_single_q(q, C, n_sites, z, spin_coefficients, couplings) for q in q_vectors]
+        energies = _calc_q_chunks(q_vectors, C, n_sites, z, spin_coefficients, couplings)
 
     #return SpinwaveResult( q_vectors=q_vectors, raw_energies=energies, method=[])
     return energies
 
 
-def _calc_single_q(q: float,
+def _get_q_chunks(q_vectors: np.ndarray, n_proc: int):
+    nq = int(np.floor(q_vectors.shape[0] / n_proc))
+    return [q_vectors[i*nq:(i+1)*nq] for i in range(n_proc - 1)] + [q_vectors[(n_proc - 1)*nq:]]
+
+
+def _calc_q_chunks(q_vectors: np.ndarray,
                    C: np.ndarray,
                    n_sites: int,
                    z: np.ndarray,
                    spin_coefficients: np.ndarray,
                    couplings: list[Coupling]):
-    """Calculate the energies for the 'Hamiltonian' h(q) for a single q-value."""
-    A = np.zeros((n_sites, n_sites), dtype=complex)
-    B = np.zeros((n_sites, n_sites), dtype=complex)
-    z_conj = z.conj()
+    """Calculate the energies for the 'Hamiltonian' h(q) for a set of q-values."""
+    energies = []
+    for q in q_vectors:
+        A = np.zeros((n_sites, n_sites), dtype=complex)
+        B = np.zeros((n_sites, n_sites), dtype=complex)
+        z_conj = z.conj()
+    
+        # Add the terms up to the total spin coefficient
+        for coupling in couplings:
+    
+            phase_factor = np.exp((2j*np.pi)*np.dot(q, coupling.inter_site_vector))
+    
+            i = coupling.index1
+            j = coupling.index2
+    
+            A[i, j] += z[i, :] @ coupling.matrix @ z_conj[j, :] * phase_factor
+            B[i, j] += z[i, :] @ coupling.matrix @ z[j, :] * phase_factor
+    
+        A *= spin_coefficients
+        B *= spin_coefficients
+        #
+        # print("A", A)
+        # print("B", B)
+        # print("C", C)
+    
+    
+        # hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
+        hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
+    
+        #
+        # We need to enforce the bosonic commutation properties, we do this
+        # by finding the 'square root' of the matrix (i.e. finding K such that KK^dagger = H)
+        # and then negating the second half.
+        #
+        # In matrix form we do
+        #
+        #     M = K^dagger C K
+        #
+        # where C is a diagonal matrix of length 2n, with the first n entries being 1, and the
+        # remaining entries being -1. Note the adjoint is on the other side to the definition in
+        # of the decomposition
+        #
+        # We can also do this via an LDL decomposition, but the method is very slightly different
+    
+    
+        try:
+            sqrt_hamiltonian = np.linalg.cholesky(hamiltonian_matrix)
+            method = CalculationMethod.CHOLESKY
+    
+        except np.linalg.LinAlgError: # Catch postive definiteness errors
+            # l, d, perm = ldl(hamiltonian_matrix) # To LDL^\dagger (i.e. adjoint on right)
+            l, d, _ = ldl(hamiltonian_matrix) # To LDL^\dagger (i.e. adjoint on right)
+            sqrt_hamiltonian = l @ np.sqrt(d)
+    
+            # TODO: Check for actual diagonal (could potentially contain non-diagonal 2x2 blocks)
+            method = CalculationMethod.LDL
+    
+    
+        sqrt_hamiltonian_with_commutation = sqrt_hamiltonian.copy()
+        sqrt_hamiltonian_with_commutation[n_sites:, :] *= -1  # This is C*K
+    
+        to_diagonalise = np.conj(sqrt_hamiltonian).T @ sqrt_hamiltonian_with_commutation
+    
+        energies.append(np.linalg.eigvals(to_diagonalise))
 
-    # Add the terms up to the total spin coefficient
-    for coupling in couplings:
-
-        phase_factor = np.exp((2j*np.pi)*np.dot(q, coupling.inter_site_vector))
-
-        i = coupling.index1
-        j = coupling.index2
-
-        A[i, j] += z[i, :] @ coupling.matrix @ z_conj[j, :] * phase_factor
-        B[i, j] += z[i, :] @ coupling.matrix @ z[j, :] * phase_factor
-
-    A *= spin_coefficients
-    B *= spin_coefficients
-    #
-    # print("A", A)
-    # print("B", B)
-    # print("C", C)
-
-
-    # hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
-    hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
-
-    #
-    # We need to enforce the bosonic commutation properties, we do this
-    # by finding the 'square root' of the matrix (i.e. finding K such that KK^dagger = H)
-    # and then negating the second half.
-    #
-    # In matrix form we do
-    #
-    #     M = K^dagger C K
-    #
-    # where C is a diagonal matrix of length 2n, with the first n entries being 1, and the
-    # remaining entries being -1. Note the adjoint is on the other side to the definition in
-    # of the decomposition
-    #
-    # We can also do this via an LDL decomposition, but the method is very slightly different
-
-
-    try:
-        sqrt_hamiltonian = np.linalg.cholesky(hamiltonian_matrix)
-        method = CalculationMethod.CHOLESKY
-
-    except np.linalg.LinAlgError: # Catch postive definiteness errors
-        # l, d, perm = ldl(hamiltonian_matrix) # To LDL^\dagger (i.e. adjoint on right)
-        l, d, _ = ldl(hamiltonian_matrix) # To LDL^\dagger (i.e. adjoint on right)
-        sqrt_hamiltonian = l @ np.sqrt(d)
-
-        # TODO: Check for actual diagonal (could potentially contain non-diagonal 2x2 blocks)
-        method = CalculationMethod.LDL
-
-
-    sqrt_hamiltonian_with_commutation = sqrt_hamiltonian.copy()
-    sqrt_hamiltonian_with_commutation[n_sites:, :] *= -1  # This is C*K
-
-    to_diagonalise = np.conj(sqrt_hamiltonian).T @ sqrt_hamiltonian_with_commutation
-
-    return np.linalg.eigvals(to_diagonalise)
-
+    return energies

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -51,10 +51,7 @@ def spinwave_calculation(rotations: np.ndarray,
     n_sites = rotations.shape[0]
 
     z = rotations[:,:,0] + 1j*rotations[:,:,1] # n-by-3, complex
-    z_conj = z.conj()
     eta = rotations[:,:,2] # n-by-3 real
-
-    # Create the A, B, and C matrices
 
     # Create the matrix sqrt(S_i S_j)/2
     root_mags = np.sqrt(0.5*magnitudes) # S_i / sqrt(2)
@@ -62,88 +59,92 @@ def spinwave_calculation(rotations: np.ndarray,
 
     energies = []
     methods = []
+
+    # calculate the C matrix for h(q), which is q-independent
+    C = np.zeros((n_sites, n_sites), dtype=complex)
+    sites_term = np.vecdot(magnitudes, eta, axis=0)
+    for coupling in couplings:
+        j = coupling.index2
+        C[j, j] += eta[j, :].T @ coupling.matrix @ sites_term
+
     for q in q_vectors:
-
-        A = np.zeros((n_sites, n_sites), dtype=complex)
-        B = np.zeros((n_sites, n_sites), dtype=complex)
-        C = np.zeros((n_sites, n_sites), dtype=complex)
-
-        # Add the terms up to the total spin coefficient
-        for coupling in couplings:
-
-            phase_factor = np.exp((2j*np.pi)*np.dot(q, coupling.inter_site_vector))
-
-            i = coupling.index1
-            j = coupling.index2
-
-            A[i, j] += z[i, :] @ coupling.matrix @ z_conj[j, :] * phase_factor
-            B[i, j] += z[i, :] @ coupling.matrix @ z[j, :] * phase_factor
-
-
-            for l in range(n_sites):
-                C[j, j] += spin_coefficients[l,l] * eta[j, :].T @ coupling.matrix @ eta[l, :]
-
-        A *= spin_coefficients
-        B *= spin_coefficients
-        C *= 2
-        #
-        # print("A", A)
-        # print("B", B)
-        # print("C", C)
-
-
-        # hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
-        hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
-
-        #
-        # We need to enforce the bosonic commutation properties, we do this
-        # by finding the 'square root' of the matrix (i.e. finding K such that KK^dagger = H)
-        # and then negating the second half.
-        #
-        # In matrix form we do
-        #
-        #     M = K^dagger C K
-        #
-        # where C is a diagonal matrix of length 2n, with the first n entries being 1, and the
-        # remaining entries being -1. Note the adjoint is on the other side to the definition in
-        # of the decomposition
-        #
-        # We can also do this via an LDL decomposition, but the method is very slightly different
-
-
-        try:
-            sqrt_hamiltonian = np.linalg.cholesky(hamiltonian_matrix)
-
-            sqrt_hamiltonian_with_commutation = sqrt_hamiltonian.copy()
-            sqrt_hamiltonian_with_commutation[:, n_sites:] *= -1
-
-            to_diagonalise = np.conj(sqrt_hamiltonian_with_commutation).T @ sqrt_hamiltonian
-
-            methods.append(CalculationMethod.CHOLESKY)
-
-        except np.linalg.LinAlgError: # Catch postive definiteness errors
-
-
-            # l, d, perm = ldl(hamiltonian_matrix) # To LDL^\dagger (i.e. adjoint on right)
-            l, d, _ = ldl(hamiltonian_matrix) # To LDL^\dagger (i.e. adjoint on right)
-            sqrt_hamiltonian = l @ np.sqrt(d)
-
-            # TODO: Check for actual diagonal (could potentially contain non-diagonal 2x2 blocks)
-
-            sqrt_hamiltonian_with_commutation = sqrt_hamiltonian.copy()
-            sqrt_hamiltonian_with_commutation[:, n_sites:] *= -1
-
-            to_diagonalise = np.conj(sqrt_hamiltonian_with_commutation).T @ sqrt_hamiltonian
-
-            methods.append(CalculationMethod.LDL)
-
-        eig_res = np.linalg.eig(to_diagonalise)
-
-        energies.append(eig_res.eigenvalues) # These are currently the square energies
-
-    # pylint: enable=C0103
+        eigenvalues, method = _calc_single_q(q, C, n_sites, z, spin_coefficients, couplings)
+        energies.append(eigenvalues)  # These are currently the square energies
+        methods.append(method)
 
     return SpinwaveResult(
                 q_vectors=q_vectors,
                 raw_energies=energies,
                 method=methods)
+
+
+def _calc_single_q(q: float,
+                   C: np.ndarray,
+                   n_sites: int,
+                   z: np.ndarray,
+                   spin_coefficients: np.ndarray,
+                   couplings: list[Coupling]):
+    """Calculate the energies for the 'Hamiltonian' h(q) for a single q-value."""
+    A = np.zeros((n_sites, n_sites), dtype=complex)
+    B = np.zeros((n_sites, n_sites), dtype=complex)
+
+    # Add the terms up to the total spin coefficient
+    for coupling in couplings:
+
+        phase_factor = np.exp((2j*np.pi)*np.dot(q, coupling.inter_site_vector))
+
+        i = coupling.index1
+        j = coupling.index2
+
+        A[i, j] += z[i, :] @ coupling.matrix @ z.conj()[j, :] * phase_factor
+        B[i, j] += z[i, :] @ coupling.matrix @ z[j, :] * phase_factor
+
+    A *= spin_coefficients
+    B *= spin_coefficients
+    #
+    # print("A", A)
+    # print("B", B)
+    # print("C", C)
+
+
+    # hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
+    hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
+
+    #
+    # We need to enforce the bosonic commutation properties, we do this
+    # by finding the 'square root' of the matrix (i.e. finding K such that KK^dagger = H)
+    # and then negating the second half.
+    #
+    # In matrix form we do
+    #
+    #     M = K^dagger C K
+    #
+    # where C is a diagonal matrix of length 2n, with the first n entries being 1, and the
+    # remaining entries being -1. Note the adjoint is on the other side to the definition in
+    # of the decomposition
+    #
+    # We can also do this via an LDL decomposition, but the method is very slightly different
+
+
+    try:
+        sqrt_hamiltonian = np.linalg.cholesky(hamiltonian_matrix)
+        method = CalculationMethod.CHOLESKY
+
+    except np.linalg.LinAlgError: # Catch postive definiteness errors
+        # l, d, perm = ldl(hamiltonian_matrix) # To LDL^\dagger (i.e. adjoint on right)
+        l, d, _ = ldl(hamiltonian_matrix) # To LDL^\dagger (i.e. adjoint on right)
+        sqrt_hamiltonian = l @ np.sqrt(d)
+
+        # TODO: Check for actual diagonal (could potentially contain non-diagonal 2x2 blocks)
+        method = CalculationMethod.LDL
+
+
+    sqrt_hamiltonian_with_commutation = sqrt_hamiltonian.copy()
+    sqrt_hamiltonian_with_commutation[:, n_sites:] *= -1
+
+    to_diagonalise = np.conj(sqrt_hamiltonian_with_commutation).T @ sqrt_hamiltonian
+
+    return np.linalg.eigvals(to_diagonalise), method
+
+
+


### PR DESCRIPTION
This PR refactors the spin-wave calculation so that it can be parallelised over q. Currently it seems that the parallelism slows things down, so I've put it behind a global flag `PARALLEL` while we're still testing things - I'll put some benchmarks together to see if it's faster for a large example. We also get a modest speed improvement as it avoids recalculating the `C` matrix for every q-value (it is q-independent) and also factors out the coupling-independent terms over sites.