### PR TITLE
Adds more examples and a benchmarking script

### DIFF
--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -1,0 +1,41 @@
+"""Example of an antiferromagnetic chain.
+
+See https://spinw.org/tutorials/02tutorial
+"""
+
+import numpy as np
+
+from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+
+def antiferro_chain():
+    """Antiferromagnetic chain.
+
+    We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
+    """
+    rotations = np.array([np.eye(3), [[-1, 0, 0], [0, 0, -1], [0, 1, 0]]])
+    magnitudes = np.array([1.5]*2)
+
+    couplings = [
+        Coupling(0, 1, -1 * rotations[0] @ rotations[1].T, inter_site_vector=np.array([0, 1, 0])),
+        Coupling(0, 1, -1  *rotations[0] @ rotations[1].T, inter_site_vector=np.array([0, -1, 0])),
+        Coupling(1, 0, -1 * rotations[1] @ rotations[0].T, inter_site_vector = np.array([0, 1, 0])),
+        Coupling(1, 0, -1 * rotations[1] @ rotations[0].T, inter_site_vector = np.array([0, -1, 0])),
+        ]
+
+    q_mags = np.linspace(0, 1, 100).reshape(-1, 1)
+    q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
+
+    return (rotations, magnitudes, q_vectors, couplings)
+
+if __name__ == "__main__":
+
+    import matplotlib.pyplot as plt
+
+    structure = antiferro_chain()
+    result = spinwave_calculation(*structure)
+
+    # Note: we get complex data types with real part zero
+
+    plt.plot(np.linspace(0, 1, 100).reshape(-1, 1), result.raw_energies)
+
+    plt.savefig("fig.png")

--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
-def antiferro_chain():
+def antiferro_chain(n_q = 100):
     """Antiferromagnetic chain.
 
     We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
@@ -22,7 +22,7 @@ def antiferro_chain():
         Coupling(1, 0, -1 * rotations[1] @ rotations[0].T, inter_site_vector = np.array([0, -1, 0])),
         ]
 
-    q_mags = np.linspace(0, 1, 100).reshape(-1, 1)
+    q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
 
     return (rotations, magnitudes, q_vectors, couplings)

--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -12,7 +12,7 @@ def antiferro_chain():
 
     We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
     """
-    rotations = np.array([np.eye(3), [[-1, 0, 0], [0, 0, -1], [0, 1, 0]]])
+    rotations = np.array([np.eye(3), [[1, 0, 0], [0, 1, 0], [0, 0, -1]]])
     magnitudes = np.array([1.5]*2)
 
     couplings = [

--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -2,7 +2,6 @@
 
 See https://spinw.org/tutorials/02tutorial
 """
-
 import numpy as np
 
 try:

--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -12,15 +12,15 @@ def antiferro_chain(n_q = 100):
 
     We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
     """
-    rotations = np.array([np.eye(3), [[1, 0, 0], [0, 1, 0], [0, 0, -1]]])
-    magnitudes = np.array([1.5]*2)
+    rotations = np.array([np.eye(3), [[-1, 0, 0], [0, 1, 0], [0, 0, -1]]])
+    magnitudes = np.array([1.0]*2)
 
     couplings = [
-        Coupling(0, 1, -1 * rotations[0] @ rotations[1].T, inter_site_vector=np.array([0, 1, 0])),
-        Coupling(0, 1, -1  *rotations[0] @ rotations[1].T, inter_site_vector=np.array([0, -1, 0])),
-        Coupling(1, 0, -1 * rotations[1] @ rotations[0].T, inter_site_vector = np.array([0, 1, 0])),
-        Coupling(1, 0, -1 * rotations[1] @ rotations[0].T, inter_site_vector = np.array([0, -1, 0])),
-        ]
+        Coupling(0, 1, np.eye(3), inter_site_vector=np.array([0, 1, 0])),
+        Coupling(0, 1, np.eye(3), inter_site_vector=np.array([0, -1, 0])),
+        Coupling(1, 0, np.eye(3), inter_site_vector=np.array([0, 1, 0])),
+        Coupling(1, 0, np.eye(3), inter_site_vector=np.array([0, -1, 0])),
+    ]
 
     q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
@@ -38,4 +38,6 @@ if __name__ == "__main__":
 
     plt.plot(np.linspace(0, 1, 100).reshape(-1, 1), result.raw_energies)
 
-    plt.savefig("fig.png")
+    #plt.savefig("fig.png")
+    # Compare with tutorial 2, second last figure (https://spinw.org/tutorial2_05.png)
+    plt.show()

--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -5,21 +5,25 @@ See https://spinw.org/tutorials/02tutorial
 
 import numpy as np
 
-from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+try:
+    from pyspinw.rust import spinwave_calculation, Coupling
+except ModuleNotFoundError:
+    from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
 def antiferro_chain(n_q = 100):
     """Antiferromagnetic chain.
 
     We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
     """
-    rotations = np.array([np.eye(3), [[-1, 0, 0], [0, 1, 0], [0, 0, -1]]])
+    rust_kw = {'dtype':complex, 'order':'F'}
+    rotations = [np.eye(3, **rust_kw), np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], **rust_kw)]
     magnitudes = np.array([1.0]*2)
 
     couplings = [
-        Coupling(0, 1, np.eye(3), inter_site_vector=np.array([0, 1, 0])),
-        Coupling(0, 1, np.eye(3), inter_site_vector=np.array([0, -1, 0])),
-        Coupling(1, 0, np.eye(3), inter_site_vector=np.array([0, 1, 0])),
-        Coupling(1, 0, np.eye(3), inter_site_vector=np.array([0, -1, 0])),
+        Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
+        Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])),
+        Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
+        Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])),
     ]
 
     q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
@@ -32,11 +36,11 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
 
     structure = antiferro_chain()
-    result = spinwave_calculation(*structure)
+    energies = spinwave_calculation(*structure)
 
     # Note: we get complex data types with real part zero
 
-    plt.plot(np.linspace(0, 1, 100).reshape(-1, 1), result.raw_energies)
+    plt.plot(np.linspace(0, 1, 100).reshape(-1, 1), energies)
 
     #plt.savefig("fig.png")
     # Compare with tutorial 2, second last figure (https://spinw.org/tutorial2_05.png)

--- a/examples/raw_calculations/benchmark.py
+++ b/examples/raw_calculations/benchmark.py
@@ -1,0 +1,23 @@
+"""Benchmark for each of the raw calculation examples."""
+from examples.raw_calculations.ferromagnetic_chain import heisenberg_ferromagnet
+from examples.raw_calculations.antiferro_chain import antiferro_chain
+from examples.raw_calculations.kagome import kagome_ferromagnet
+from examples.raw_calculations.kagome_supercell import kagome_supercell
+
+from prettytable import PrettyTable
+from timeit import timeit
+
+from pyspinw.calculations.spinwave import spinwave_calculation
+
+table = PrettyTable()
+table.field_names = ["n_q", "ferromagnetic_chain", "antiferro_chain", "kagome_ferromagnet", "kagome_supercell"]
+
+for n_q in [100, 1000, 5000]:
+    times = []
+    for example in ["heisenberg_ferromagnet", "antiferro_chain", "kagome_ferromagnet", "kagome_supercell"]:
+        times.append(timeit('spinwave_calculation(*structure)', setup=f'structure = {example}(n_q={n_q})', globals=globals(), number=10))
+
+    table.add_row([n_q] + [f"{time:4f}" for time in times])
+
+print(table)
+

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -11,7 +11,7 @@ def heisenberg_ferromagnet(n_q = 100):
 
     # Single site
     rotations = np.eye(3).reshape(1, 3, 3)
-    magnitudes = np.array([1.5])  # spin 3/2
+    magnitudes = np.array([1.0])  # spin-1
     couplings = [Coupling(0, 0, np.eye(3), inter_site_vector=np.array([0, 1, 0])),
                  Coupling(0, 0, np.eye(3), inter_site_vector=np.array([0, -1, 0])),
                  ]
@@ -22,12 +22,14 @@ if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
 
-    structure = heisenberg_ferromagnet()
-    q_mags = np.linspace(0, 1, len(q_vectors))
+    n_q = 100
+    structure = heisenberg_ferromagnet(n_q)
+    q_mags = np.linspace(0, 1, n_q)
     energies = spinwave_calculation(*structure)
 
     # Note: we get complex data types with real part zero
 
-    plt.plot(q_mags, result.raw_energies)
+    plt.plot(q_mags, energies.raw_energies)
 
+    # Compare with tutorial 1, 3rd last figure (https://spinw.org/tutorial1_05.png)
     plt.show()

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -1,14 +1,16 @@
+"""Basic Heisenberg ferromagnetic chain example.
+
+See https://spinw.org/tutorials/01tutorial
+"""
 import numpy as np
-#try:
-#    from pyspinw.rust import spinwave_calculation, Coupling
-#except ModuleNotFoundError:
-from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+
+try:
+    from pyspinw.rust import Coupling, spinwave_calculation
+except ModuleNotFoundError:
+    from pyspinw.calculations.spinwave import Coupling, spinwave_calculation
 
 def heisenberg_ferromagnet(n_q = 100):
-    """
-    Basic ferromagnet
-    """
-
+    """Basic ferromagnet."""
     q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
 

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -1,13 +1,12 @@
 import numpy as np
 from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
-def heisenberg_ferromagnet():
-
+def heisenberg_ferromagnet(n_q = 100):
     """
     Basic ferromagnet
     """
 
-    q_mags = np.linspace(0, 1, 100).reshape(-1, 1)
+    q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
 
     # Single site
@@ -17,14 +16,14 @@ def heisenberg_ferromagnet():
                  Coupling(0, 0, np.eye(3), inter_site_vector=np.array([0, -1, 0])),
                  ]
 
-    structure = (rotations, magnitudes, q_vectors, couplings)
-    return structure, q_mags
+    return (rotations, magnitudes, q_vectors, couplings)
 
 if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
 
-    structure, q_mags = heisenberg_ferromagnet()
+    structure = heisenberg_ferromagnet()
+    q_mags = np.linspace(0, 1, len(q_vectors))
     energies = spinwave_calculation(*structure)
 
     # Note: we get complex data types with real part zero

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -17,18 +17,15 @@ def heisenberg_ferromagnet():
                  Coupling(0, 0, np.eye(3), inter_site_vector=np.array([0, -1, 0])),
                  ]
 
-    energies = spinwave_calculation(rotations,
-                                    magnitudes,
-                                    q_vectors,
-                                    couplings)
-
-    return q_mags, energies
+    structure = (rotations, magnitudes, q_vectors, couplings)
+    return structure, q_mags
 
 if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
 
-    q_mags, result = heisenberg_ferromagnet()
+    structure, q_mags = heisenberg_ferromagnet()
+    energies = spinwave_calculation(*structure)
 
     # Note: we get complex data types with real part zero
 

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -1,8 +1,8 @@
 import numpy as np
-try:
-    from pyspinw.rust import spinwave_calculation, Coupling
-except ModuleNotFoundError:
-    from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+#try:
+#    from pyspinw.rust import spinwave_calculation, Coupling
+#except ModuleNotFoundError:
+from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
 def heisenberg_ferromagnet(n_q = 100):
     """
@@ -13,7 +13,7 @@ def heisenberg_ferromagnet(n_q = 100):
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
 
     # Single site
-    rotations = np.array([np.eye(3, dtype=complex, order='F')])
+    rotations = [np.eye(3, dtype=complex, order='F')]
     magnitudes = np.array([1.0])  # spin-1
     couplings = [Coupling(0, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=np.array([0., 1., 0.])),
                  Coupling(0, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=np.array([0., -1., 0.])), ]
@@ -31,7 +31,7 @@ if __name__ == "__main__":
 
     # Note: we get complex data types with real part zero
 
-    plt.plot(q_mags, energies.raw_energies)
+    plt.plot(q_mags, energies)
 
     # Compare with tutorial 1, 3rd last figure (https://spinw.org/tutorial1_05.png)
     plt.show()

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
-def kagome_ferromagnet():
+def kagome_ferromagnet(n_q = 100):
 
     """
     Basic ferromagnet
@@ -39,8 +39,7 @@ def kagome_ferromagnet():
                  ]
 
 
-    n_q = 101
-    q_mags = 0.5*np.linspace(0, 1, n_q).reshape(-1, 1)
+    q_mags = 0.5*np.linspace(0, 1, n_q + 1).reshape(-1, 1)
 
     # q_vectors = np.concatenate((
     #         q_mags[::-1].reshape(-1, 1) * np.array([1, 0, 1]).reshape(1, -1),
@@ -53,6 +52,15 @@ def kagome_ferromagnet():
 
     # q_vectors = q_mags.reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1)
 
+    return (rotations, magnitudes, q_vectors, couplings)
+
+if __name__ == "__main__":
+
+    import matplotlib.pyplot as plt
+
+    structure = kagome_ferromagnet()
+    q_vectors = structure[2]
+
     indices = np.arange(201)
 
     label_indices = [0, 100, 200]
@@ -60,14 +68,6 @@ def kagome_ferromagnet():
 
     labels = [str(q_vectors[idx,:]) for idx in label_indices]
 
-    structure = (rotations, magnitudes, q_vectors, couplings)
-    return structure, indices, labels, label_indices
-
-if __name__ == "__main__":
-
-    import matplotlib.pyplot as plt
-
-    structure, indices, labels, label_indices = kagome_ferromagnet()
     result = spinwave_calculation(*structure)
 
     energies = [np.sort(energy.real) for energy in result.raw_energies]

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -9,7 +9,7 @@ def kagome_ferromagnet(n_q = 100):
 
     # Three sites, otherwise identical
     rotations = np.array([np.eye(3) for _ in range(3)])
-    magnitudes = np.array([1.5]*3)  # spin 3/2
+    magnitudes = np.array([1.0]*3)  # spin-1
 
     # Each site coupled to two of each of the others, so there are 6 couplings,
     # And we need to add the other direction, so 12 entries in total
@@ -46,8 +46,8 @@ def kagome_ferromagnet(n_q = 100):
     #         q_mags[1:].reshape(-1, 1) * np.array([0, 0, 1]).reshape(1, -1)
     # ))
     q_vectors = np.concatenate((
-            q_mags[::-1].reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1),
-            q_mags[1:].reshape(-1, 1) * np.array([0, 1, 0]).reshape(1, -1)
+            q_mags[::-1].reshape(-1, 1) * np.array([-1, 0, 0]).reshape(1, -1),
+            q_mags[1:].reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1)
     ))
 
     # q_vectors = q_mags.reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1)
@@ -70,17 +70,9 @@ if __name__ == "__main__":
 
     result = spinwave_calculation(*structure)
 
-    energies = [np.sort(energy.real) for energy in result.raw_energies]
-
-    positive_energies = [energy[energy>0] for energy in energies]
-    min_energy = min([np.min(energy) for energy in positive_energies])
-    translated_energies = [energy - min_energy for energy in positive_energies]
-
-
-    # Note: we get complex data types with real part zero
-
-    plt.plot(indices, translated_energies)
+    plt.plot(indices, result.raw_energies)
     # plt.plot(indices, [method.value for method in result.method])
     plt.xticks(label_indices, labels)
 
+    # Compare with tutorial 5, 3rd last figure (https://spinw.org/tutorial5_05.png)
     plt.show()

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -60,18 +60,15 @@ def kagome_ferromagnet():
 
     labels = [str(q_vectors[idx,:]) for idx in label_indices]
 
-    result = spinwave_calculation(rotations,
-                                    magnitudes,
-                                    q_vectors,
-                                    couplings)
-
-    return result, indices, labels, label_indices
+    structure = (rotations, magnitudes, q_vectors, couplings)
+    return structure, indices, labels, label_indices
 
 if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
 
-    result, indices, labels, label_indices = kagome_ferromagnet()
+    structure, indices, labels, label_indices = kagome_ferromagnet()
+    result = spinwave_calculation(*structure)
 
     energies = [np.sort(energy.real) for energy in result.raw_energies]
 

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -1,15 +1,16 @@
+"""Kagome ferromagnet example.
+
+See https://spinw.org/tutorials/05tutorial.
+"""
 import numpy as np
+
 try:
     from pyspinw.rust import spinwave_calculation, Coupling
 except ModuleNotFoundError:
     from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
 def kagome_ferromagnet(n_q = 100):
-
-    """
-    Basic ferromagnet
-    """
-
+    """Basic ferromagnet on a kagome lattice."""
     # Three sites, otherwise identical
     rotations = [np.eye(3, dtype=complex, order='F') for _ in range(3)]
     magnitudes = np.array([1.0]*3)  # spin-1

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -11,7 +11,7 @@ def kagome_ferromagnet(n_q = 100):
     """
 
     # Three sites, otherwise identical
-    rotations = np.array([np.eye(3, dtype=complex, order='F') for _ in range(3)])
+    rotations = [np.eye(3, dtype=complex, order='F') for _ in range(3)]
     magnitudes = np.array([1.0]*3)  # spin-1
 
     # Each site coupled to two of each of the others, so there are 6 couplings,
@@ -54,28 +54,22 @@ def kagome_ferromagnet(n_q = 100):
     ))
 
     # q_vectors = q_mags.reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1)
+    return rotations, magnitudes, q_vectors, couplings
 
-    indices = np.arange(201)
-
-    label_indices = [0, 100, 200]
-    # label_indices = []
-
-    labels = [str(q_vectors[idx,:]) for idx in label_indices]
-
-    result = spinwave_calculation(rotations,
-                                    magnitudes,
-                                    q_vectors,
-                                    couplings)
-
-    return result, indices, labels, label_indices
 
 if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
 
-    result, indices, labels, label_indices = kagome_ferromagnet()
+    indices = np.arange(201)
 
-    plt.plot(indices, result.raw_energies)
+    label_indices = [0, 100, 200]
+
+    rotations, magnitudes, q_vectors, couplings = kagome_ferromagnet(100)
+    labels = [str(q_vectors[idx,:]) for idx in label_indices]
+    energies = spinwave_calculation(rotations, magnitudes, q_vectors, couplings)
+
+    plt.plot(indices, np.real(energies))
     # plt.plot(indices, [method.value for method in result.method])
     plt.xticks(label_indices, labels)
 

--- a/examples/raw_calculations/kagome_antiferro.py
+++ b/examples/raw_calculations/kagome_antiferro.py
@@ -1,0 +1,122 @@
+import numpy as np
+from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+
+# define our rotation matrices
+def rotation(theta):
+    """
+    returns a matrix whose columns are [e1==real(zed) e2==imag(zed) e3=eta]
+    which serves to rotate spins into FM alignment according to
+    Toth and Lake JPCM 27 16602 (2016), for a spin in the x-y plane rotated
+    at an angle theta to the x-axis.
+    """
+    """ # From Matlab SpinW
+    e3 = np.array([np.sin(theta), np.cos(theta), 0.0])
+    e2 = np.cross(e3, np.array([1.0, 0.0, 0.0]))
+    if np.linalg.norm(e2) < 1e-6:
+        e2 = np.array([0.0, 0.0, 1.0])
+    e2 = e2 / np.linalg.norm(e2)
+    e1 = np.cross(e2, e3)
+    return np.array([e1, e2, e3]).T
+    """
+    # From Lukas
+    return np.array(
+        [
+            [np.cos(theta), 0, np.sin(theta)],
+            [np.sin(theta), 0, -np.cos(theta)],
+            [0, 1, 0],
+        ]
+    )
+
+def kagome_antiferromagnet(n_q = 100):
+    """
+    Kagome anti-ferromagnet like in tutorial 7
+    """
+
+    # Three sites, otherwise identical
+    rotations = np.array([
+        rotation(0),
+        rotation(2 * np.pi / 3),
+        rotation(-2 * np.pi / 3)
+    ])
+    magnitudes = np.array([1.0]*3)  # spin-1
+
+    # Do the J1 (nearest neighbour) couplings - using table from Matlab Tutorial 7
+    # Run the example until the end and then run:
+    # >> AFkagome.table('bond',1:2)
+    # And use the values in idx1, idx2, and dl (idx1, idx2 indexed from 1 not 0)
+    J1mat = np.eye(3) * 1.0
+    couplings = [
+        Coupling(2, 0, J1mat, [0, 1, 0]),
+        Coupling(0, 1, J1mat, [0, -1, 0]),
+        Coupling(1, 2, J1mat, [0, 0, 0]),
+        Coupling(2, 0, J1mat, [0, 0, 0]),
+        Coupling(0, 1, J1mat, [1, 0, 0]),
+        Coupling(1, 2, J1mat, [-1, 0, 0]),
+    ]
+    # Also need the conjugate coupling
+    couplings.extend([
+        Coupling(0, 2, J1mat, [0, -1, 0]),
+        Coupling(1, 0, J1mat, [0, 1, 0]),
+        Coupling(2, 1, J1mat, [0, 0, 0]),
+        Coupling(0, 2, J1mat, [0, 0, 0]),
+        Coupling(1, 0, J1mat, [-1, 0, 0]),
+        Coupling(2, 1, J1mat, [1, 0, 0]),
+    ])
+
+    # Do the J2 (next-nearest-neigbour) couplings
+    J2mat = np.eye(3) * 0.11
+    couplings.extend([
+        Coupling(0, 1, J2mat, [1, -1, 0]),
+        Coupling(1, 2, J2mat, [0, 1, 0]),
+        Coupling(2, 0, J2mat, [-1, 0, 0]),
+        Coupling(0, 1, J2mat, [0, 0, 0]),
+        Coupling(1, 2, J2mat, [-1, -1, 0]),
+        Coupling(2, 0, J2mat, [1, 1, 0]),
+    ])
+    couplings.extend([
+        Coupling(1, 0, J2mat, [-1, 1, 0]),
+        Coupling(2, 1, J2mat, [0, -1, 0]),
+        Coupling(0, 2, J2mat, [1, 0, 0]),
+        Coupling(1, 0, J2mat, [0, 0, 0]),
+        Coupling(2, 1, J2mat, [1, 1, 0]),
+        Coupling(0, 2, J2mat, [-1, -1, 0]),
+    ])
+
+    q_mags = 0.5*np.linspace(0, 1, n_q + 1).reshape(-1, 1)
+
+    q_vectors = np.concatenate((
+            q_mags[::-1].reshape(-1, 1) * np.array([-1, 0, 0]).reshape(1, -1),
+            q_mags[1:].reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1)
+    ))
+
+    return (rotations, magnitudes, q_vectors, couplings)
+
+if __name__ == "__main__":
+
+    import matplotlib.pyplot as plt
+
+    structure = kagome_antiferromagnet()
+    q_vectors = structure[2]
+
+    indices = np.arange(201)
+
+    label_indices = [0, 100, 200]
+    # label_indices = []
+
+    labels = [str(q_vectors[idx,:]) for idx in label_indices]
+
+    result = spinwave_calculation(*structure)
+
+    # Ignore imaginary energies (we shouldn't get any here...)
+    energies = [np.sort(energy.real) for energy in result.raw_energies]
+
+    positive_energies = [energy[energy>0] for energy in energies]
+
+    plt.plot(indices, positive_energies)
+    # plt.plot(indices, [method.value for method in result.method])
+    plt.xticks(label_indices, labels)
+
+    # Compare with tutorial 7, 2nd last figure (https://spinw.org/tutorial7_05.png)
+    # It looks slightly assymmetric because Matlab-SpinW adjusts the aspect-ratio
+    # so that each unit along the x-axis is the same |Q| value whatever the direction
+    plt.show()

--- a/examples/raw_calculations/kagome_antiferro.py
+++ b/examples/raw_calculations/kagome_antiferro.py
@@ -1,11 +1,19 @@
+"""Kagome antiferromagnet example.
+
+See https://spinw.org/tutorials/07tutorial.
+"""
 import numpy as np
-#from pyspinw.rust import spinwave_calculation, Coupling
-from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+
+try:
+    from pyspinw.rust import spinwave_calculation, Coupling
+except ModuleNotFoundError:
+    from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
 # define our rotation matrices
 def rotation(theta):
-    """
-    returns a matrix whose columns are [e1==real(zed) e2==imag(zed) e3=eta]
+    """Calculates the rotation matrix for a given x-y plane angle theta.
+
+    Returns a matrix whose columns are [e1==real(zed) e2==imag(zed) e3=eta]
     which serves to rotate spins into FM alignment according to
     Toth and Lake JPCM 27 16602 (2016), for a spin in the x-y plane rotated
     at an angle theta to the x-axis.
@@ -30,10 +38,7 @@ def rotation(theta):
     )
 
 def kagome_antiferromagnet(n_q = 100):
-    """
-    Kagome anti-ferromagnet like in tutorial 7
-    """
-
+    """Kagome anti-ferromagnet like in tutorial 7."""
     # Three sites, otherwise identical
     rotations = [
         rotation(0),

--- a/examples/raw_calculations/kagome_antiferro.py
+++ b/examples/raw_calculations/kagome_antiferro.py
@@ -1,4 +1,5 @@
 import numpy as np
+#from pyspinw.rust import spinwave_calculation, Coupling
 from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
 # define our rotation matrices
@@ -24,7 +25,8 @@ def rotation(theta):
             [np.cos(theta), 0, np.sin(theta)],
             [np.sin(theta), 0, -np.cos(theta)],
             [0, 1, 0],
-        ]
+        ],
+        dtype=complex, order='F',
     )
 
 def kagome_antiferromagnet(n_q = 100):
@@ -33,53 +35,53 @@ def kagome_antiferromagnet(n_q = 100):
     """
 
     # Three sites, otherwise identical
-    rotations = np.array([
+    rotations = [
         rotation(0),
         rotation(2 * np.pi / 3),
         rotation(-2 * np.pi / 3)
-    ])
+    ]
     magnitudes = np.array([1.0]*3)  # spin-1
 
     # Do the J1 (nearest neighbour) couplings - using table from Matlab Tutorial 7
     # Run the example until the end and then run:
     # >> AFkagome.table('bond',1:2)
     # And use the values in idx1, idx2, and dl (idx1, idx2 indexed from 1 not 0)
-    J1mat = np.eye(3) * 1.0
+    J1mat = np.eye(3, dtype=complex, order='F') * 1.0
     couplings = [
-        Coupling(2, 0, J1mat, [0, 1, 0]),
-        Coupling(0, 1, J1mat, [0, -1, 0]),
-        Coupling(1, 2, J1mat, [0, 0, 0]),
-        Coupling(2, 0, J1mat, [0, 0, 0]),
-        Coupling(0, 1, J1mat, [1, 0, 0]),
-        Coupling(1, 2, J1mat, [-1, 0, 0]),
+        Coupling(2, 0, J1mat, np.array([0., 1, 0])),
+        Coupling(0, 1, J1mat, np.array([0., -1, 0])),
+        Coupling(1, 2, J1mat, np.array([0., 0, 0])),
+        Coupling(2, 0, J1mat, np.array([0., 0, 0])),
+        Coupling(0, 1, J1mat, np.array([1., 0, 0])),
+        Coupling(1, 2, J1mat, np.array([-1., 0, 0])),
     ]
     # Also need the conjugate coupling
     couplings.extend([
-        Coupling(0, 2, J1mat, [0, -1, 0]),
-        Coupling(1, 0, J1mat, [0, 1, 0]),
-        Coupling(2, 1, J1mat, [0, 0, 0]),
-        Coupling(0, 2, J1mat, [0, 0, 0]),
-        Coupling(1, 0, J1mat, [-1, 0, 0]),
-        Coupling(2, 1, J1mat, [1, 0, 0]),
+        Coupling(0, 2, J1mat, np.array([0., -1, 0])),
+        Coupling(1, 0, J1mat, np.array([0., 1, 0])),
+        Coupling(2, 1, J1mat, np.array([0., 0, 0])),
+        Coupling(0, 2, J1mat, np.array([0., 0, 0])),
+        Coupling(1, 0, J1mat, np.array([-1., 0, 0])),
+        Coupling(2, 1, J1mat, np.array([1., 0, 0])),
     ])
 
     # Do the J2 (next-nearest-neigbour) couplings
-    J2mat = np.eye(3) * 0.11
+    J2mat = np.eye(3, dtype=complex, order='F') * 0.11
     couplings.extend([
-        Coupling(0, 1, J2mat, [1, -1, 0]),
-        Coupling(1, 2, J2mat, [0, 1, 0]),
-        Coupling(2, 0, J2mat, [-1, 0, 0]),
-        Coupling(0, 1, J2mat, [0, 0, 0]),
-        Coupling(1, 2, J2mat, [-1, -1, 0]),
-        Coupling(2, 0, J2mat, [1, 1, 0]),
+        Coupling(0, 1, J2mat, np.array([1., -1, 0])),
+        Coupling(1, 2, J2mat, np.array([0., 1, 0])),
+        Coupling(2, 0, J2mat, np.array([-1., 0, 0])),
+        Coupling(0, 1, J2mat, np.array([0., 0, 0])),
+        Coupling(1, 2, J2mat, np.array([-1., -1, 0])),
+        Coupling(2, 0, J2mat, np.array([1., 1, 0])),
     ])
     couplings.extend([
-        Coupling(1, 0, J2mat, [-1, 1, 0]),
-        Coupling(2, 1, J2mat, [0, -1, 0]),
-        Coupling(0, 2, J2mat, [1, 0, 0]),
-        Coupling(1, 0, J2mat, [0, 0, 0]),
-        Coupling(2, 1, J2mat, [1, 1, 0]),
-        Coupling(0, 2, J2mat, [-1, -1, 0]),
+        Coupling(1, 0, J2mat, np.array([-1., 1, 0])),
+        Coupling(2, 1, J2mat, np.array([0., -1, 0])),
+        Coupling(0, 2, J2mat, np.array([1., 0, 0])),
+        Coupling(1, 0, J2mat, np.array([0., 0, 0])),
+        Coupling(2, 1, J2mat, np.array([1., 1, 0])),
+        Coupling(0, 2, J2mat, np.array([-1., -1, 0])),
     ])
 
     q_mags = 0.5*np.linspace(0, 1, n_q + 1).reshape(-1, 1)
@@ -105,10 +107,10 @@ if __name__ == "__main__":
 
     labels = [str(q_vectors[idx,:]) for idx in label_indices]
 
-    result = spinwave_calculation(*structure)
+    energies = spinwave_calculation(*structure)
 
     # Ignore imaginary energies (we shouldn't get any here...)
-    energies = [np.sort(energy.real) for energy in result.raw_energies]
+    energies = [np.sort(energy.real) for energy in energies]
 
     positive_energies = [energy[energy>0] for energy in energies]
 

--- a/examples/raw_calculations/kagome_supercell.py
+++ b/examples/raw_calculations/kagome_supercell.py
@@ -1,0 +1,142 @@
+"""Example of a Kagome supercell.
+
+This is the magnet in MATLAB SpinW tutorial 8:
+    https://spinw.org/tutorials/08tutorial
+"""
+
+import numpy as np
+
+from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+
+def sym_coupling(idx1, idx2, inter_site_vector):
+    """Create a symmetric coupling."""
+    return (Coupling(idx1, idx2, np.eye(3), inter_site_vector),
+            Coupling(idx2, idx1, np.eye(3), -inter_site_vector))
+
+def unit_cell_couplings(cell_number: int):
+    """Create all the couplings within a unit cell."""
+    k = 0.5
+    c = cell_number*3
+    return      [
+                 *sym_coupling(c, c+1, k*np.array([ 1,  0, 0])),
+                 *sym_coupling(c, c+1, k*np.array([-1,  0, 0])),
+                 *sym_coupling(c, c+2, k*np.array([ 1,  1, 0])),
+                 *sym_coupling(c, c+2, k*np.array([-1, -1, 0])),
+                 *sym_coupling(c+1, c+2, k*np.array([ 0,  1, 0])),
+                 *sym_coupling(c+1, c+2, k*np.array([ 0, -1, 0])),
+                 ]
+
+# define our rotation matrices
+def rotation(theta):
+    """Return the rotation matrix for an angle `theta` in the x-z plane."""
+    return np.array([[np.cos(theta), np.sin(theta), 0],
+                    [0, 0, -1],
+                    [np.sin(theta), -np.cos(theta), 0]])
+
+def kagome_supercell():
+    """A sqrt(3) x sqrt(3) Kagome antiferromagnet supercell lattice."""
+    # we index the supercell by indexing each unit cell in order: so that the
+    # 'central' atom is 0 mod 3, the top-left atom is 1 mod 3, the right is 2 mod 3
+    # so we can create the unit cell couplings and then we just need to add
+    # the remaining couplings between unit cells
+    # here over the 3x3 supercell it is done as
+    #
+    # 6 \ 7 \ 8
+    # ----------
+    #  3 \ 4 \ 5
+    #  ----------
+    #   0 \ 1 \ 2
+    #
+    def down():
+        # ↙️
+        return rotation(7*np.pi/6)
+    def up():
+        # ↖
+        return rotation(np.pi/6)
+    def right():
+        # →
+        return rotation(np.pi/2)
+
+    rotations = np.array([down(),
+                          right(),
+                          right(),
+                          up(),
+                          down(),
+                          down(),
+                          right(),
+                          up(),
+                          up(),
+                          up(),
+                          down(),
+                          down(),
+                          right(),
+                          up(),
+                          up(),
+                          down(),
+                          right(),
+                          right(),
+                          right(),
+                          up(),
+                          up(),
+                          down(),
+                          right(),
+                          right(),
+                          up(),
+                          down(),
+                          down()
+                          ])
+    magnitudes = np.array([1]*27)  # spin 1
+
+    k = 0.5
+
+    couplings = []
+
+    for cell in range(0, 8):
+        couplings.extend(unit_cell_couplings(cell))
+
+    n_q = 101
+    q_mags = 0.5*np.linspace(0, 1, n_q).reshape(-1, 1)
+
+    # q_vectors = np.concatenate((
+    #         q_mags[::-1].reshape(-1, 1) * np.array([1, 0, 1]).reshape(1, -1),
+    #         q_mags[1:].reshape(-1, 1) * np.array([0, 0, 1]).reshape(1, -1)
+    # ))
+    q_vectors = np.concatenate((
+            q_mags[::-1].reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1),
+            q_mags[1:].reshape(-1, 1) * np.array([0, 1, 0]).reshape(1, -1)
+    ))
+
+    # q_vectors = q_mags.reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1)
+
+    indices = np.arange(201)
+
+    label_indices = [0, 100, 200]
+    # label_indices = []
+
+    labels = [str(q_vectors[idx,:]) for idx in label_indices]
+
+    structure = (rotations, magnitudes, q_vectors, couplings)
+
+    return structure, indices, labels, label_indices
+
+if __name__ == "__main__":
+
+    import matplotlib.pyplot as plt
+
+    structure, indices, labels, label_indices = kagome_supercell()
+    energies = spinwave_calculation(*structure).raw_energies
+
+    energies = [np.sort(energy.real) for energy in energies]
+
+    positive_energies = [energy[energy>0] for energy in energies]
+    min_energy = min([np.min(energy) for energy in positive_energies])
+    translated_energies = [energy - min_energy for energy in positive_energies]
+
+
+    # Note: we get complex data types with real part zero
+
+    plt.plot(indices, translated_energies)
+    # plt.plot(indices, [method.value for method in result.method])
+    plt.xticks(label_indices, labels)
+
+    plt.savefig("fig.png")

--- a/examples/raw_calculations/kagome_supercell.py
+++ b/examples/raw_calculations/kagome_supercell.py
@@ -12,11 +12,11 @@ from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 # define our rotation matrices
 def rotation(theta):
     """Return the rotation matrix for an angle `theta` in the x-z plane."""
-    return -1 * np.array(
+    return np.array(
         [
-            [np.cos(theta), -np.sin(theta), 0],
-            [np.sin(theta), np.cos(theta), 0],
-            [0, 0, 1],
+            [np.cos(theta), 0, np.sin(theta)],
+            [np.sin(theta), 0, -np.cos(theta)],
+            [0, 1, 0],
         ]
     )
 
@@ -36,13 +36,14 @@ def kagome_supercell(n_q = 100):
     #  ----------
     #   0 \ 1 \ 2
     #
+    # Within each unit cell there are 3 spins, at (0.5, 0), (0, 0.5) and (0.5, 0.5)
     def down():
         # ↙️
-        return rotation(np.pi / 6)
+        return rotation(-np.pi / 6)
 
     def up():
         # ↖
-        return rotation(7 * np.pi / 6)
+        return rotation(-5 * np.pi / 6)
 
     def right():
         # →
@@ -50,7 +51,15 @@ def kagome_supercell(n_q = 100):
 
     rotations = np.array(
         [
+            up(),    # Cell 0, (0.5, 0)
+            up(),    # Cell 0, (0, 0.5)
+            down(),  # Cell 0, (0.5, 0.5)
+            right(), # Cell 1, (0.5, 0)
+            right(), # Cell 1, (0, 0.5)
+            up(),    # Cell 1, (0.5, 0.5)
             down(),
+            down(),
+            right(),
             right(),
             right(),
             up(),
@@ -59,15 +68,9 @@ def kagome_supercell(n_q = 100):
             right(),
             up(),
             up(),
-            up(),
             down(),
             down(),
-            right(),
-            up(),
-            up(),
             down(),
-            right(),
-            right(),
             right(),
             up(),
             up(),
@@ -75,45 +78,38 @@ def kagome_supercell(n_q = 100):
             right(),
             right(),
             up(),
-            down(),
-            down(),
         ]
     )
     magnitudes = np.array([1] * 27)  # spin 1
 
-    k = 0.5
-
-    horizontal_pairs = [  # couplings which are parallel to the a-axis
-        (0, 2), (2, 3), (3, 5), (5, 6), (6, 8),  # bottom horizontal line
-        (9, 11), (11, 12), (12, 14), (14, 15), (15, 17),  # middle horizontal line
-        (18, 20), (20, 21), (21, 23), (23, 24), (24, 26),  # top horizontal line
-        (8, 0), (17, 9), (26, 18),  # 'over the edges' from left
+    # The inter_site_vector is actually the vector between unit cells (see eq 10 and eq 14 in Toth+Lake)
+    # So we define the pairs within each cell first - there are 2 for each cell
+    other_pairs = [
+        (0, 2), (1, 2),      (3, 5), (4, 5),      (6, 8), (7, 8),     # Cells 0-2
+        (9, 11), (10, 11),   (12, 14), (13, 14),  (15, 17), (16, 17), # Cells 3-5
+        (18, 20), (19, 20),  (21, 23), (22, 23),  (24, 26), (25, 26), # Cells 6-8
     ]
-
-    vertical_pairs = [  # pairs which are parallel to the b-axis
-        (0, 1), (1, 9), (9, 10), (10, 18), (18, 19),  # leftmost vertical line
-        (3, 4), (4, 12), (12, 13), (13, 21), (21, 22),  # middle vertical line
-        (6, 7), (7, 15), (15, 16), (16, 24), (24, 25),  # rightmost vertical line
-        (19, 0), (22, 3), (25, 6),  # 'over the edges' from bottom
+    # Now, couplings between unit cells parallel to the a-axis (also two per cell)
+    horizontal_pairs = [
+        (0, 4), (2, 4),      (3, 7), (5, 7),      (6, 1), (8, 1),     # Cells 0-2
+        (9, 13), (11, 13),   (12, 16), (14, 16),  (15, 10), (17, 10), # Cells 3-5
+        (18, 22), (20, 22),  (21, 25), (23, 25),  (24, 19), (26, 19), # Cells 6-8
     ]
-
-    other_pairs = [  # pairs going diagonally up and to the right
-        (1, 11), (11, 13), (13, 23), (23, 25), (8, 1),  # line extending through site 1 (including over edge to 8)
-        (2, 4), (4, 14), (14, 16), (16, 26), (19, 2),  # line extending through site 2 (including over edge to 19)
-        (5, 7), (7, 17), (22, 5),  # line extending through site 5 (including over edge to 22)
-        (10, 20), (20, 22), (17, 10),  # line extending through site 10 (including over edge to 17)
-        (25, 8), (26, 19),  # over edges which aren't otherwise part of a line
+    # Now, couplings between unit cells parallel to the b-axis (also two per cell)
+    vertical_pairs = [
+        (1, 9), (2, 9),      (4, 12), (5, 12),    (7, 15), (8, 15),   # Cells 0-2
+        (10, 18), (11, 18),  (13, 21), (14, 21),  (16, 24), (17, 24), # Cells 3-5
+        (19, 0), (20, 0),    (22, 3), (23, 3),    (25, 6), (26, 6),   # Cells 6-8
     ]
 
     couplings = []
 
-    k = 0.5
-    couplings.extend(Coupling(idx1, idx2, rotations[idx1] @ rotations[idx2].T, k*np.array([1, 0, 0])) for (idx1, idx2) in horizontal_pairs)
-    couplings.extend(Coupling(idx2, idx1, rotations[idx2] @ rotations[idx1].T, k*np.array([-1, 0, 0])) for (idx1, idx2) in horizontal_pairs)
-    couplings.extend(Coupling(idx1, idx2, rotations[idx1] @ rotations[idx2].T, k*np.array([0, 1, 0])) for (idx1, idx2) in vertical_pairs)
-    couplings.extend(Coupling(idx2, idx1, rotations[idx2] @ rotations[idx1].T, k*np.array([0, -1, 0])) for (idx1, idx2) in vertical_pairs)
-    couplings.extend(Coupling(idx1, idx2, rotations[idx1] @ rotations[idx2].T, k*np.array([1, 1, 0])) for (idx1, idx2) in other_pairs)
-    couplings.extend(Coupling(idx2, idx1, rotations[idx2] @ rotations[idx1].T, k*np.array([-1, -1, 0])) for (idx1, idx2) in other_pairs)
+    couplings.extend(Coupling(idx1, idx2, np.eye(3), np.array([1, 0, 0])) for (idx1, idx2) in horizontal_pairs)
+    couplings.extend(Coupling(idx2, idx1, np.eye(3), np.array([-1, 0, 0])) for (idx1, idx2) in horizontal_pairs)
+    couplings.extend(Coupling(idx1, idx2, np.eye(3), np.array([0, 1, 0])) for (idx1, idx2) in vertical_pairs)
+    couplings.extend(Coupling(idx2, idx1, np.eye(3), np.array([0, -1, 0])) for (idx1, idx2) in vertical_pairs)
+    couplings.extend(Coupling(idx1, idx2, np.eye(3), np.array([0, 0, 0])) for (idx1, idx2) in other_pairs)
+    couplings.extend(Coupling(idx2, idx1, np.eye(3), np.array([0, 0, 0])) for (idx1, idx2) in other_pairs)
 
     q_mags = 0.5 * np.linspace(0, 1, n_q + 1).reshape(-1, 1)
 
@@ -123,8 +119,8 @@ def kagome_supercell(n_q = 100):
     # ))
     q_vectors = np.concatenate(
         (
-            q_mags[::-1].reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1),
-            q_mags[1:].reshape(-1, 1) * np.array([0, 1, 0]).reshape(1, -1),
+            q_mags[::-1].reshape(-1, 1) * np.array([-1, 0, 0]).reshape(1, -1),
+            q_mags[1:].reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1),
         )
     )
 
@@ -159,4 +155,5 @@ if __name__ == "__main__":
     # plt.plot(indices, [method.value for method in result.method])
     plt.xticks(label_indices, labels)
 
-    plt.savefig("fig.png")
+    #plt.savefig("fig.png")
+    plt.show()

--- a/examples/raw_calculations/kagome_supercell.py
+++ b/examples/raw_calculations/kagome_supercell.py
@@ -21,7 +21,7 @@ def rotation(theta):
     )
 
 
-def kagome_supercell():
+def kagome_supercell(n_q = 100):
     """A sqrt(3) x sqrt(3) Kagome antiferromagnet supercell lattice."""
 
     # we index the supercell by indexing each unit cell in order: so that the
@@ -115,8 +115,7 @@ def kagome_supercell():
     couplings.extend(Coupling(idx1, idx2, rotations[idx1] @ rotations[idx2].T, k*np.array([1, 1, 0])) for (idx1, idx2) in other_pairs)
     couplings.extend(Coupling(idx2, idx1, rotations[idx2] @ rotations[idx1].T, k*np.array([-1, -1, 0])) for (idx1, idx2) in other_pairs)
 
-    n_q = 101
-    q_mags = 0.5 * np.linspace(0, 1, n_q).reshape(-1, 1)
+    q_mags = 0.5 * np.linspace(0, 1, n_q + 1).reshape(-1, 1)
 
     # q_vectors = np.concatenate((
     #         q_mags[::-1].reshape(-1, 1) * np.array([1, 0, 1]).reshape(1, -1),
@@ -131,6 +130,14 @@ def kagome_supercell():
 
     # q_vectors = q_mags.reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1)
 
+    return (rotations, magnitudes, q_vectors, couplings)
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+
+    structure = kagome_supercell()
+    q_vectors = structure[2]
+
     indices = np.arange(201)
 
     label_indices = [0, 100, 200]
@@ -138,15 +145,6 @@ def kagome_supercell():
 
     labels = [str(q_vectors[idx, :]) for idx in label_indices]
 
-    structure = (rotations, magnitudes, q_vectors, couplings)
-
-    return structure, indices, labels, label_indices
-
-
-if __name__ == "__main__":
-    import matplotlib.pyplot as plt
-
-    structure, indices, labels, label_indices = kagome_supercell()
     energies = spinwave_calculation(*structure).raw_energies
 
     energies = [np.sort(energy.real) for energy in energies]

--- a/examples/raw_calculations/kagome_supercell.py
+++ b/examples/raw_calculations/kagome_supercell.py
@@ -3,11 +3,12 @@
 This is the magnet in MATLAB SpinW tutorial 8:
     https://spinw.org/tutorials/08tutorial
 """
-
 import numpy as np
 
-#from pyspinw.rust import spinwave_calculation, Coupling
-from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+try:
+    from pyspinw.rust import spinwave_calculation, Coupling
+except ModuleNotFoundError:
+    from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
 
 # define our rotation matrices

--- a/examples/raw_calculations/kagome_supercell.py
+++ b/examples/raw_calculations/kagome_supercell.py
@@ -6,6 +6,7 @@ This is the magnet in MATLAB SpinW tutorial 8:
 
 import numpy as np
 
+#from pyspinw.rust import spinwave_calculation, Coupling
 from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
 
 
@@ -17,7 +18,8 @@ def rotation(theta):
             [np.cos(theta), 0, np.sin(theta)],
             [np.sin(theta), 0, -np.cos(theta)],
             [0, 1, 0],
-        ]
+        ],
+        dtype=complex, order='F',
     )
 
 
@@ -49,8 +51,7 @@ def kagome_supercell(n_q = 100):
         # →
         return rotation(np.pi / 2)
 
-    rotations = np.array(
-        [
+    rotations = [
             up(),    # Cell 0, (0.5, 0)
             up(),    # Cell 0, (0, 0.5)
             down(),  # Cell 0, (0.5, 0.5)
@@ -79,7 +80,6 @@ def kagome_supercell(n_q = 100):
             right(),
             up(),
         ]
-    )
     magnitudes = np.array([1] * 27)  # spin 1
 
     # The inter_site_vector is actually the vector between unit cells (see eq 10 and eq 14 in Toth+Lake)
@@ -104,12 +104,13 @@ def kagome_supercell(n_q = 100):
 
     couplings = []
 
-    couplings.extend(Coupling(idx1, idx2, np.eye(3), np.array([1, 0, 0])) for (idx1, idx2) in horizontal_pairs)
-    couplings.extend(Coupling(idx2, idx1, np.eye(3), np.array([-1, 0, 0])) for (idx1, idx2) in horizontal_pairs)
-    couplings.extend(Coupling(idx1, idx2, np.eye(3), np.array([0, 1, 0])) for (idx1, idx2) in vertical_pairs)
-    couplings.extend(Coupling(idx2, idx1, np.eye(3), np.array([0, -1, 0])) for (idx1, idx2) in vertical_pairs)
-    couplings.extend(Coupling(idx1, idx2, np.eye(3), np.array([0, 0, 0])) for (idx1, idx2) in other_pairs)
-    couplings.extend(Coupling(idx2, idx1, np.eye(3), np.array([0, 0, 0])) for (idx1, idx2) in other_pairs)
+    rskw = {'dtype':complex, 'order':'F'}
+    couplings.extend(Coupling(idx1, idx2, np.eye(3, **rskw), np.array([1., 0, 0])) for (idx1, idx2) in horizontal_pairs)
+    couplings.extend(Coupling(idx2, idx1, np.eye(3, **rskw), np.array([-1., 0, 0])) for (idx1, idx2) in horizontal_pairs)
+    couplings.extend(Coupling(idx1, idx2, np.eye(3, **rskw), np.array([0., 1, 0])) for (idx1, idx2) in vertical_pairs)
+    couplings.extend(Coupling(idx2, idx1, np.eye(3, **rskw), np.array([0., -1, 0])) for (idx1, idx2) in vertical_pairs)
+    couplings.extend(Coupling(idx1, idx2, np.eye(3, **rskw), np.array([0., 0, 0])) for (idx1, idx2) in other_pairs)
+    couplings.extend(Coupling(idx2, idx1, np.eye(3, **rskw), np.array([0., 0, 0])) for (idx1, idx2) in other_pairs)
 
     q_mags = 0.5 * np.linspace(0, 1, n_q + 1).reshape(-1, 1)
 
@@ -141,7 +142,7 @@ if __name__ == "__main__":
 
     labels = [str(q_vectors[idx, :]) for idx in label_indices]
 
-    energies = spinwave_calculation(*structure).raw_energies
+    energies = spinwave_calculation(*structure)
 
     energies = [np.sort(energy.real) for energy in energies]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,6 @@ fn _spinwave_single_q(
     }
     else { 
         let (l, d) = ldl(hamiltonian);
-        println!("{}", d);
         l * DMatrix::from_diagonal(&d.map(nalgebra::Complex::sqrt))
     }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,14 +108,16 @@ fn _calc_spinwave(
     // where M is the coupling matrix and S_i is the i'th spin
     // and we factor the l-dependent part out into `sites_term`
     // to avoid recalculating it for every coupling
-    let sites_term: Vector3<C64> = zip(magnitudes, etas.clone())
-        .map(|(magnitude, eta)| eta * Complex::from(magnitude))
-        .sum::<Vector3<C64>>();
+    //let sites_term: Vector3<C64> = zip(magnitudes, etas.clone())
+    //    .map(|(magnitude, eta)| eta * Complex::from(magnitude))
+    //    .sum::<Vector3<C64>>();
     let mut C = DMatrix::<C64>::zeros(n_sites, n_sites);
     for c in &couplings {
         *C.index_mut((c.index2, c.index2)) +=
-            (etas[c.index2].transpose() * c.matrix * sites_term).into_scalar();
+          //(etas[c.index2].transpose() * c.matrix * sites_term).into_scalar();
+            spin_coefficients[(c.index2, c.index2)] * (etas[c.index1].transpose() * c.matrix * etas[c.index2]).into_scalar();
     }
+    C *= Complex::from(2.);
 
     q_vectors
         .into_par_iter()
@@ -171,13 +173,15 @@ fn _spinwave_single_q(
     //     M = K^dagger g K
     //
     // where g is a diagonal matrix of length 2n, with the first n entries being 1, and the
-    // remaining entries being -1. We do this by just multiplying the >n_sites columns of shc.
+    // remaining entries being -1. 
+    // We do this by just multiplying the >n_sites rows of shc to get g*K
     let mut shc: DMatrix<C64> = sqrt_hamiltonian.clone();
-    let mut negative_half = shc.view_mut((0, n_sites), (2 * n_sites, n_sites));
+    //let mut negative_half = shc.view_mut((0, n_sites), (2 * n_sites, n_sites));
+    let mut negative_half = shc.view_mut((n_sites, 0), (n_sites, 2 * n_sites));
     negative_half *= Complex::from(-1.);
 
     // calculate eigenvalues (energies) of the Hamiltonian and return
-    if let Some(v) = (shc.adjoint() * sqrt_hamiltonian).eigenvalues() {
+    if let Some(v) = (sqrt_hamiltonian.adjoint() * shc).eigenvalues() {
         v.data.into()
     } else {
         panic!("Could not calculate eigenvalues of the Hamiltonian.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::f64::consts::PI;
 use std::{iter::zip, ops::Sub};
 
-use nalgebra::{stack, Const, Cholesky, DMatrix, DMatrixView, DVector, Dyn, Matrix3, Vector3};
+use nalgebra::{stack, Const, DMatrix, DMatrixView, DVector, Dyn, Matrix3, Vector3};
 use num_complex::Complex;
 use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArray2, PyReadwriteArray2, ToPyArray};
 use pyo3::prelude::*;
@@ -103,12 +103,19 @@ fn _calc_spinwave(
     let spin_coefficients = (root_mags.clone() * root_mags.transpose()).transpose();
 
     // create matrix C of Hamiltonian which is q-independent
+    //
+    // C_jj is the sum of eta_j^T * M * S_l eta_l over l
+    // where M is the coupling matrix and S_i is the i'th spin
+    // and we factor the l-dependent part out into `sites_term`
+    // to avoid recalculating it for every coupling
+    let sites_term: Vector3<C64> = zip(magnitudes, etas.clone())
+        .map(|(magnitude, eta)| eta * Complex::from(magnitude))
+        .sum::<Vector3<C64>>();
     let mut C = DMatrix::<C64>::zeros(n_sites, n_sites);
     for c in &couplings {
-        C[(c.index2, c.index2)] += spin_coefficients[(c.index2, c.index2)]
-            * (etas[c.index1].transpose() * c.matrix * etas[c.index2]).into_scalar();
+        *C.index_mut((c.index2, c.index2)) +=
+            (etas[c.index2].transpose() * c.matrix * sites_term).into_scalar();
     }
-    C *= Complex::from(2.);
 
     q_vectors
         .into_par_iter()
@@ -148,15 +155,10 @@ fn _spinwave_single_q(
     let hamiltonian: DMatrix<C64> = stack![ A_minus_C, B; 
                                             B.adjoint(), A_conj_minus_C];
 
-    // take square root of Hamiltonian using the LDL decomposition
+    // take square root of Hamiltonian using the LDL decomposition 
     let sqrt_hamiltonian = {
-    if let Some(chol) = Cholesky::new(hamiltonian.clone()) {
-        chol.l()
-    }
-    else { 
         let (l, d) = ldl(hamiltonian);
         l * DMatrix::from_diagonal(&d.map(nalgebra::Complex::sqrt))
-    }
     };
 
     // 'shc' is "square root of Hamiltonian with commutation"
@@ -169,14 +171,13 @@ fn _spinwave_single_q(
     //     M = K^dagger g K
     //
     // where g is a diagonal matrix of length 2n, with the first n entries being 1, and the
-    // remaining entries being -1.
-    // We do this by just multiplying the >n_sites rows of shc to get g*K
+    // remaining entries being -1. We do this by just multiplying the >n_sites columns of shc.
     let mut shc: DMatrix<C64> = sqrt_hamiltonian.clone();
-    let mut negative_half = shc.view_mut((n_sites, 0), (n_sites, 2 * n_sites));
+    let mut negative_half = shc.view_mut((0, n_sites), (2 * n_sites, n_sites));
     negative_half *= Complex::from(-1.);
 
     // calculate eigenvalues (energies) of the Hamiltonian and return
-    if let Some(v) = (sqrt_hamiltonian.adjoint() * shc).eigenvalues() {
+    if let Some(v) = (shc.adjoint() * sqrt_hamiltonian).eigenvalues() {
         v.data.into()
     } else {
         panic!("Could not calculate eigenvalues of the Hamiltonian.")
@@ -186,7 +187,7 @@ fn _spinwave_single_q(
 fn _get_rotation_component(rotations: &Vec<Matrix3<C64>>, index: usize) -> Vec<Vector3<C64>> {
     rotations
         .par_iter()
-        .map(|r| r.column(index).into_owned())
+        .map(|r| r.row(index).transpose())
         .collect()
 }
 


### PR DESCRIPTION
This PR refactors the examples so they each consist of a function which creates the structure, and then the actual run is done in the `if __name__ == "__main__"` block. This makes it easier to just grab the structures of the examples so they can be run in a benchmarking script (which has been added as `benchmark.py` in the folder.

This also adds two additional examples:
- `antiferro_chain.py`: the structure from https://spinw.org/tutorials/02tutorial, to have a simple example where the rotations are not all trivial
- `kagome_supercell.py`: the structure from https://spinw.org/tutorials/08tutorial, a 3x3 supercell of the Kagome lattice to test an example for a large number of sites