### PR TITLE
Adds Rust version of spinwave calculation 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pySpinW"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "rust"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = {version="0.24.2", features=["num-complex"]}
+numpy = {version="0.24.0", features=["nalgebra"]}
+nalgebra = "0.33.2" 
+num-complex = "0.4.6"
+rayon = "1.10.0"

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+from pyspinw.rust import spinwave_calculation, Coupling
 
 def heisenberg_ferromagnet():
 
@@ -11,10 +11,10 @@ def heisenberg_ferromagnet():
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
 
     # Single site
-    rotations = np.eye(3).reshape(1, 3, 3)
+    rotations = [np.eye(3, dtype=complex, order='F')]
     magnitudes = np.array([1.5])  # spin 3/2
-    couplings = [Coupling(0, 0, np.eye(3), inter_site_vector=np.array([0, 1, 0])),
-                 Coupling(0, 0, np.eye(3), inter_site_vector=np.array([0, -1, 0])),
+    couplings = [Coupling(0, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=np.array([0., 1., 0.])),
+                 Coupling(0, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=np.array([0., -1., 0.])),
                  ]
 
     energies = spinwave_calculation(rotations,
@@ -32,6 +32,6 @@ if __name__ == "__main__":
 
     # Note: we get complex data types with real part zero
 
-    plt.plot(q_mags, result.raw_energies)
+    plt.plot(q_mags, result)
 
     plt.show()

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pyspinw.calculations.spinwave import spinwave_calculation, Coupling
+from pyspinw.rust import spinwave_calculation, Coupling
 
 def kagome_ferromagnet():
 
@@ -8,7 +8,7 @@ def kagome_ferromagnet():
     """
 
     # Three sites, otherwise identical
-    rotations = np.array([np.eye(3) for _ in range(3)])
+    rotations = [np.eye(3, dtype=complex, order='F') for _ in range(3)]
     magnitudes = np.array([1.5]*3)  # spin 3/2
 
     # Each site coupled to two of each of the others, so there are 6 couplings,
@@ -24,18 +24,18 @@ def kagome_ferromagnet():
     k = 0.5
 
     couplings = [
-                 Coupling(0, 1, np.eye(3), inter_site_vector=k*np.array([ 1,  0, 0])),
-                 Coupling(0, 1, np.eye(3), inter_site_vector=k*np.array([-1,  0, 0])),
-                 Coupling(1, 0, np.eye(3), inter_site_vector=k*np.array([ 1,  0, 0])),
-                 Coupling(1, 0, np.eye(3), inter_site_vector=k*np.array([-1,  0, 0])),
-                 Coupling(0, 2, np.eye(3), inter_site_vector=k*np.array([ 1,  1, 0])),
-                 Coupling(0, 2, np.eye(3), inter_site_vector=k*np.array([-1, -1, 0])),
-                 Coupling(2, 0, np.eye(3), inter_site_vector=k*np.array([ 1,  1, 0])),
-                 Coupling(2, 0, np.eye(3), inter_site_vector=k*np.array([-1, -1, 0])),
-                 Coupling(1, 2, np.eye(3), inter_site_vector=k*np.array([ 0,  1, 0])),
-                 Coupling(1, 2, np.eye(3), inter_site_vector=k*np.array([ 0, -1, 0])),
-                 Coupling(2, 1, np.eye(3), inter_site_vector=k*np.array([ 0,  1, 0])),
-                 Coupling(2, 1, np.eye(3), inter_site_vector=k*np.array([ 0, -1, 0]))
+                 Coupling(0, 1, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([ 1.,  0., 0.])),
+                 Coupling(0, 1, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([-1.,  0., 0.])),
+                 Coupling(1, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([ 1.,  0., 0.])),
+                 Coupling(1, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([-1.,  0., 0.])),
+                 Coupling(0, 2, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([ 1.,  1., 0.])),
+                 Coupling(0, 2, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([-1., -1., 0.])),
+                 Coupling(2, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([ 1.,  1., 0.])),
+                 Coupling(2, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([-1., -1., 0.])),
+                 Coupling(1, 2, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([ 0.,  1., 0.])),
+                 Coupling(1, 2, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([ 0., -1., 0.])),
+                 Coupling(2, 1, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([ 0.,  1., 0.])),
+                 Coupling(2, 1, np.eye(3, dtype=complex, order='F'), inter_site_vector=k*np.array([ 0., -1., 0.]))
                  ]
 
 
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 
     result, indices, labels, label_indices = kagome_ferromagnet()
 
-    energies = [np.sort(energy.real) for energy in result.raw_energies]
+    energies = [np.sort(energy.real) for energy in result]
 
     positive_energies = [energy[energy>0] for energy in energies]
     min_energy = min([np.min(energy) for energy in positive_energies])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,20 @@
-# TODO: Fill this out fully
+[build-system]
+requires = ["maturin>=1.3,<2.0"]
+build-backend = "maturin"
 
 [project]
-name = "PySpinW"
+name = "pySpinW"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
 dynamic = ["version"]
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+module-name = "pyspinw.rust"
 
 [tool.setuptools.dynamic]
 version = {attr = "pyspinw.__version__"}

--- a/src/ldl.rs
+++ b/src/ldl.rs
@@ -3,6 +3,10 @@ use num_complex::Complex;
 
 type C64 = Complex<f64>;
 
+// This algorithm is a modified copy of https://github.com/dimforge/nalgebra/pull/1515
+// and when that pull request is merged, should be deleted and replaced with a call to
+// `ldl` from the nalgebra library.
+
 /// Computes the LDL^T factorization.
 ///
 /// The input matrix `p` is assumed to be Hermitian and this decomposition will only read

--- a/src/ldl.rs
+++ b/src/ldl.rs
@@ -1,0 +1,45 @@
+use nalgebra::{Const, DMatrix, DVector};
+use num_complex::Complex;
+
+type C64 = Complex<f64>;
+
+/// Computes the LDL^T factorization.
+///
+/// The input matrix `p` is assumed to be Hermitian and this decomposition will only read
+/// the lower-triangular part of `p`.
+pub fn ldl(p: DMatrix<C64>) -> (DMatrix<C64>, DVector<C64>) {
+    let n = p.ncols();
+
+    let n_dim = p.shape_generic().1;
+
+    let mut d = DVector::<C64>::zeros_generic(n_dim, Const::<1>);
+    let mut l = DMatrix::<C64>::zeros_generic(n_dim, n_dim);
+
+    for j in 0..n {
+        let mut d_j = p[(j, j)];
+
+        if j > 0 {
+            for k in 0..j {
+                d_j -= d[k] * l[(j, k)].clone().powi(2);
+            }
+        }
+
+        d[j] = d_j;
+
+        for i in j..n {
+            let mut l_ij = p[(j, i)];
+
+            for k in 0..j {
+                l_ij -= d[k] * l[(j, k)] * l[(i, k)];
+            }
+
+            if d[j] == Complex::from(0.) {
+                l[(i, j)] = Complex::from(0.)
+            } else {
+                l[(i, j)] = l_ij / d[j];
+            }
+        }
+    }
+
+    (l, d)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,202 @@
+use std::f64::consts::PI;
+use std::{iter::zip, ops::Sub};
+
+use nalgebra::{stack, Const, DMatrix, DMatrixView, DVector, Dyn, Matrix3, Vector3};
+use num_complex::Complex;
+use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArray2, PyReadwriteArray2, ToPyArray};
+use pyo3::prelude::*;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+
+pub mod ldl;
+use crate::ldl::ldl;
+
+// some convenience types and statics for complex arithmetic
+type C64 = Complex<f64>;
+static J: C64 = Complex::new(0., 1.);
+
+/// Temporary description of the coupling between atoms.
+#[pyclass(frozen)]
+pub struct Coupling {
+    index1: usize,
+    index2: usize,
+    matrix: Matrix3<C64>,
+    inter_site_vector: Vector3<f64>,
+}
+
+#[pymethods]
+impl Coupling {
+    #[new]
+    fn new(
+        index1: usize,
+        index2: usize,
+        matrix: PyReadonlyArray2<C64>,
+        inter_site_vector: PyReadonlyArray1<f64>,
+    ) -> Self {
+        Coupling {
+            index1,
+            index2,
+            matrix: matrix
+                .try_as_matrix::<Const<3>, Const<3>, Dyn, Dyn>()
+                .unwrap()
+                .into(),
+            inter_site_vector: inter_site_vector
+                .try_as_matrix::<Const<3>, Const<1>, Dyn, Dyn>()
+                .unwrap()
+                .into(),
+        }
+    }
+}
+
+/// Run the main calculation step for a spinwave calculation.
+#[pyfunction]
+pub fn spinwave_calculation<'py>(
+    py: Python<'py>,
+    rotations: Vec<PyReadwriteArray2<C64>>,
+    magnitudes: Vec<f64>,
+    q_vectors: Vec<Vec<f64>>,
+    couplings: Vec<Py<Coupling>>,
+) -> PyResult<Vec<Bound<'py, PyArray1<C64>>>> {
+    // convert PyO3-friendly array types to nalgebra matrices
+    let r: Vec<Matrix3<C64>> = rotations
+        .into_iter()
+        .map(|m| -> Matrix3<C64> {
+            let mv: DMatrixView<C64> = m.try_as_matrix().unwrap();
+            mv.fixed_resize::<3, 3>(Complex::from(0.))
+        })
+        .collect();
+    let qv = q_vectors.into_par_iter().map(Vector3::from_vec).collect();
+
+    let c = couplings.par_iter().map(pyo3::Py::get).collect();
+
+    let energies = _calc_spinwave(r, magnitudes, qv, c);
+    Ok(energies.into_iter().map(|v| v.to_pyarray(py)).collect())
+}
+
+/// Run the main calculation step for a spinwave calculation.
+#[allow(non_snake_case)]
+fn _calc_spinwave(
+    rotations: Vec<Matrix3<C64>>,
+    magnitudes: Vec<f64>,
+    q_vectors: Vec<Vector3<f64>>,
+    couplings: Vec<&Coupling>,
+) -> Vec<Vec<C64>> {
+    let n_sites = rotations.len();
+
+    // in the notation of Petit (2011)
+    // eta[i] is the direction of the i'th moment in Cartesian coordinates
+    let z: Vec<Vector3<C64>> = zip(
+        _get_rotation_component(&rotations, 0),
+        _get_rotation_component(&rotations, 1),
+    )
+    .map(|(r1, r2)| r1 + (r2 * J))
+    .collect();
+    let eta = _get_rotation_component(&rotations, 2);
+
+    // make spin coefficients array
+    // so spin_coefficients[i, j] = sqrt(S_i S_j) / 2
+    let root_mags = DVector::<C64>::from_iterator(
+        n_sites,
+        magnitudes.iter().map(|x| Complex::from((0.5 * x).sqrt())),
+    );
+    let spin_coefficients = (root_mags.clone() * root_mags.transpose()).transpose();
+
+    // create matrix C of Hamiltonian which is q-independent
+    //
+    // C_jj is the sum of eta_j^T * M * S_l eta_l over l
+    // where M is the coupling matrix and S_i is the i'th spin
+    // and we factor the l-dependent part out into `sites_term`
+    // to avoid recalculating it for every coupling
+    let sites_term: Vector3<C64> = zip(magnitudes, eta.clone())
+        .map(|(m, e)| e * Complex::from(m))
+        .sum::<Vector3<C64>>();
+    let mut C = DMatrix::<C64>::zeros(n_sites, n_sites);
+    for c in &couplings {
+        *C.index_mut((c.index2, c.index2)) +=
+            (eta[c.index2].transpose() * c.matrix * sites_term).into_scalar();
+    }
+
+    q_vectors
+        .into_par_iter()
+        .map(|q| _spinwave_single_q(q, &C, n_sites, &z, &spin_coefficients, &couplings))
+        .collect()
+}
+
+/// Calculate spectra for a single q-value.
+#[allow(non_snake_case)]
+fn _spinwave_single_q(
+    q: Vector3<f64>,
+    C: &DMatrix<C64>,
+    n_sites: usize,
+    z: &[Vector3<C64>],
+    spin_coefficients: &DMatrix<C64>,
+    couplings: &Vec<&Coupling>,
+) -> Vec<C64> {
+    // create A and B matrices for the Hamiltonian
+
+    let mut A = DMatrix::<C64>::zeros(n_sites, n_sites);
+    let mut B = DMatrix::<C64>::zeros(n_sites, n_sites);
+
+    for c in couplings {
+        let phase_factor = ((2. * J * PI) * q.dot(&c.inter_site_vector)).exp();
+        let (i, j) = (c.index1, c.index2);
+
+        A[(i, j)] += (z[i].transpose() * c.matrix * z[j].conjugate()).into_scalar() * phase_factor;
+        B[(i, j)] += (z[i].transpose() * c.matrix * z[j]).into_scalar() * phase_factor;
+    }
+
+    A = A.component_mul(spin_coefficients);
+    B = B.component_mul(spin_coefficients);
+
+    // create Hamiltonian as a block matrix (the stack! macro creates a block matrix)
+    let A_minus_C: DMatrix<C64> = A.clone().sub(C);
+    let A_conj_minus_C: DMatrix<C64> = A.adjoint().sub(C);
+    let hamiltonian: DMatrix<C64> = stack![ A_minus_C, B; 
+                                            B.adjoint(), A_conj_minus_C];
+
+    // try to take square root of Hamiltonian with Cholesky; if it fails, use LDL
+    let sqrt_hamiltonian = {
+        let (l, d) = ldl(hamiltonian);
+        l * DMatrix::from_diagonal(&d.map(nalgebra::Complex::sqrt))
+        //match hamiltonian.cholesky() {
+        //  Some(m) => m.l(),
+        //None => panic!(), // hamiltonian.ldl().unwrap().l
+        //}
+    };
+
+    // 'shc' is "square root of Hamiltonian with commutation"
+    // We need to enforce the bosonic commutation properties, we do this
+    // by finding the 'square root' of the matrix (i.e. finding K such that KK^dagger = H)
+    // and then negating the second half.
+    //
+    // In matrix form we do
+    //
+    //     M = K^dagger g K
+    //
+    // where g is a diagonal matrix of length 2n, with the first n entries being 1, and the
+    // remaining entries being -1. We do this by just multiplying the >n_sites columns of shc.
+    let mut shc: DMatrix<C64> = sqrt_hamiltonian.clone();
+    let mut negative_half = shc.view_mut((0, n_sites), (2 * n_sites, n_sites));
+    negative_half *= Complex::from(-1.);
+
+    if let Some(v) = (shc.adjoint() * sqrt_hamiltonian).eigenvalues() {
+        v.data.into()
+    } else {
+        panic!()
+    }
+}
+/// Get the component of the rotation matrix for the axis indexed by `index`.
+fn _get_rotation_component(rotations: &Vec<Matrix3<C64>>, index: usize) -> Vec<Vector3<C64>> {
+    rotations
+        .par_iter()
+        .map(|r| r.row(index).transpose())
+        .collect()
+}
+
+/// A Python module implemented in Rust.
+#[pymodule]
+fn rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(spinwave_calculation, m)?)?;
+    m.add_class::<Coupling>()?;
+    Ok(())
+}


### PR DESCRIPTION
Adds a Rust version of the spinwave calculation. Fixes #50

This uses the `maturin` build system. In short, to compile (with [rust installed](https://rustup.rs/)):
- type `maturin develop` to compile a dev build
- type `maturin develop --release` to compile a release build

Note some small changes to the low-level data:
- `rotations` is now a list of arrays rather than a 3D array of arrays
- currently you must ensure that the datatype of any rotation/coupling matrix is complex, and that the datatype of the coupling inter-site vector is a float (NOT an integer!). I think I'd ideally like to be handling this at the frontend as handling it within Rust is a bit of a pain