### PR TITLE
Lock ruff version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
-ruff
+ruff==0.11.13
 pytest


### PR DESCRIPTION
This PR locks the `ruff` version so that the linter CI doesn't suddenly start failing when an update adds a new lint.