### PR TITLE
Allow example language selection and add unit test for comparing implementations

### DIFF
--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -5,26 +5,17 @@ See https://spinw.org/tutorials/02tutorial
 import sys
 
 import numpy as np
+from pyspinw.calculations.spinwave import Coupling as PyCoupling
 
-try:
-    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
-    RUST_AVAILABLE = True
-except ModuleNotFoundError:
-    RUST_AVAILABLE = False
+from examples.raw_calculations.utils import run_example
 
-from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
-
-def antiferro_chain(n_q = 100, rust = False):
+def antiferro_chain(n_q = 100, coupling_class = PyCoupling):
     """Antiferromagnetic chain.
 
     We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
     """
-    if rust:
-        rust_kw = {'dtype':complex, 'order':'F'}
-        Coupling = RsCoupling
-    else:
-        rust_kw = {}
-        Coupling = PyCoupling
+    rust_kw = {'dtype':complex, 'order':'F'}
+    Coupling = coupling_class
 
     rotations = [np.eye(3, **rust_kw), np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], **rust_kw)]
     magnitudes = np.array([1.0]*2)
@@ -45,11 +36,12 @@ if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
 
-    use_rust = ("py" not in sys.argv[1]) if len(sys.argv) > 1 else RUST_AVAILABLE
-    spinwave_calculation = rs_spinwave if use_rust else py_spinwave
+    if len(sys.argv) > 1:
+        use_rust = "py" not in sys.argv[1]
+    else:
+        use_rust = True
 
-    structure = antiferro_chain(rust = use_rust)
-    energies = spinwave_calculation(*structure)
+    _, energies = run_example(antiferro_chain, use_rust)
 
     # Note: we get complex data types with real part zero
 

--- a/examples/raw_calculations/benchmark.py
+++ b/examples/raw_calculations/benchmark.py
@@ -2,22 +2,40 @@
 from examples.raw_calculations.ferromagnetic_chain import heisenberg_ferromagnet
 from examples.raw_calculations.antiferro_chain import antiferro_chain
 from examples.raw_calculations.kagome import kagome_ferromagnet
+from examples.raw_calculations.kagome_antiferro import kagome_antiferromagnet
 from examples.raw_calculations.kagome_supercell import kagome_supercell
 
 from prettytable import PrettyTable
 from timeit import timeit
 
-from pyspinw.calculations.spinwave import spinwave_calculation
+try:
+    from pyspinw.rust import spinwave_calculation as rs_spinwave
+    RUST_AVAILABLE = True
+except ModuleNotFoundError:
+    RUST_AVAILABLE = False
+
+from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave
+
+examples = ["heisenberg_ferromagnet", "antiferro_chain", "kagome_ferromagnet", "kagome_antiferromagnet", "kagome_supercell"]
 
 table = PrettyTable()
-table.field_names = ["n_q", "ferromagnetic_chain", "antiferro_chain", "kagome_ferromagnet", "kagome_supercell"]
+table.field_names = ["n_q"] + examples
 
-for n_q in [100, 1000, 5000]:
-    times = []
-    for example in ["heisenberg_ferromagnet", "antiferro_chain", "kagome_ferromagnet", "kagome_supercell"]:
-        times.append(timeit('spinwave_calculation(*structure)', setup=f'structure = {example}(n_q={n_q})', globals=globals(), number=10))
+RUST_AVAILABLE = False
+rust_option = [False, True] if RUST_AVAILABLE else [False]
 
-    table.add_row([n_q] + [f"{time:4f}" for time in times])
+for use_rust in rust_option:
+    if use_rust:
+        spinwave_calculation = 'rs_spinwave'
+    else:
+        spinwave_calculation = 'py_spinwave'
 
-print(table)
+    for n_q in [100, 1000, 5000]:
+        times = []
+        for example in examples:
+            times.append(timeit(f'{spinwave_calculation}(*structure)', setup=f'structure = {example}(n_q={n_q}, rust={use_rust})', globals=globals(), number=10))
+
+        table.add_row([n_q] + [f"{time:4f}" for time in times])
+
+    print(table)
 

--- a/examples/raw_calculations/benchmark.py
+++ b/examples/raw_calculations/benchmark.py
@@ -1,4 +1,5 @@
 """Benchmark for each of the raw calculation examples."""
+
 from examples.raw_calculations.ferromagnetic_chain import heisenberg_ferromagnet
 from examples.raw_calculations.antiferro_chain import antiferro_chain
 from examples.raw_calculations.kagome import kagome_ferromagnet
@@ -9,33 +10,46 @@ from prettytable import PrettyTable
 from timeit import timeit
 
 try:
-    from pyspinw.rust import spinwave_calculation as rs_spinwave
+    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
     RUST_AVAILABLE = True
 except ModuleNotFoundError:
     RUST_AVAILABLE = False
 
-from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave
+from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
 
-examples = ["heisenberg_ferromagnet", "antiferro_chain", "kagome_ferromagnet", "kagome_antiferromagnet", "kagome_supercell"]
+examples = [
+    "heisenberg_ferromagnet",
+    "antiferro_chain",
+    "kagome_ferromagnet",
+    "kagome_antiferromagnet",
+    "kagome_supercell",
+]
 
-table = PrettyTable()
-table.field_names = ["n_q"] + examples
-
-RUST_AVAILABLE = False
 rust_option = [False, True] if RUST_AVAILABLE else [False]
 
 for use_rust in rust_option:
     if use_rust:
-        spinwave_calculation = 'rs_spinwave'
+        spinwave_calculation = "rs_spinwave"
+        coupling_class = "RsCoupling"
     else:
-        spinwave_calculation = 'py_spinwave'
+        spinwave_calculation = "py_spinwave"
+        coupling_class = "PyCoupling"
+
+    table = PrettyTable()
+    table.field_names = ["n_q"] + examples
 
     for n_q in [100, 1000, 5000]:
         times = []
         for example in examples:
-            times.append(timeit(f'{spinwave_calculation}(*structure)', setup=f'structure = {example}(n_q={n_q}, rust={use_rust})', globals=globals(), number=10))
+            times.append(
+                timeit(
+                    f"{spinwave_calculation}(*structure)",
+                    setup=f"structure = {example}(n_q={n_q}, coupling_class = {coupling_class})",
+                    globals=globals(),
+                    number=10,
+                )
+            )
 
         table.add_row([n_q] + [f"{time:4f}" for time in times])
 
     print(table)
-

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -5,23 +5,14 @@ See https://spinw.org/tutorials/01tutorial
 import sys
 
 import numpy as np
+from pyspinw.calculations.spinwave import Coupling as PyCoupling
 
-try:
-    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
-    RUST_AVAILABLE = True
-except ModuleNotFoundError:
-    RUST_AVAILABLE = False
+from examples.raw_calculations.utils import run_example
 
-from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
-
-def heisenberg_ferromagnet(n_q = 100, rust = False):
+def heisenberg_ferromagnet(n_q = 100, coupling_class = PyCoupling):
     """Basic ferromagnet."""
-    if rust:
-        rust_kw = {'dtype':complex, 'order':'F'}
-        Coupling = RsCoupling
-    else:
-        rust_kw = {}
-        Coupling = PyCoupling
+    rust_kw = {'dtype':complex, 'order':'F'}
+    Coupling = coupling_class
 
     q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
@@ -38,16 +29,16 @@ if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
 
-    n_q = 100
-    use_rust = ("py" not in sys.argv[1]) if len(sys.argv) > 1 else RUST_AVAILABLE
-    spinwave_calculation = rs_spinwave if use_rust else py_spinwave
-    q_mags = np.linspace(0, 1, n_q)
+    if len(sys.argv) > 1:
+        use_rust = "py" not in sys.argv[1]
+    else:
+        use_rust = True
 
-    structure = heisenberg_ferromagnet(n_q, rust=use_rust)
-    energies = spinwave_calculation(*structure)
+    q_mags = np.linspace(0, 1, 100)
+
+    _, energies = run_example(heisenberg_ferromagnet, use_rust)
 
     # Note: we get complex data types with real part zero
-
     plt.plot(q_mags, energies)
 
     # Compare with tutorial 1, 3rd last figure (https://spinw.org/tutorial1_05.png)

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -2,23 +2,35 @@
 
 See https://spinw.org/tutorials/01tutorial
 """
+import sys
+
 import numpy as np
 
 try:
-    from pyspinw.rust import Coupling, spinwave_calculation
+    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
+    RUST_AVAILABLE = True
 except ModuleNotFoundError:
-    from pyspinw.calculations.spinwave import Coupling, spinwave_calculation
+    RUST_AVAILABLE = False
 
-def heisenberg_ferromagnet(n_q = 100):
+from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
+
+def heisenberg_ferromagnet(n_q = 100, rust = False):
     """Basic ferromagnet."""
+    if rust:
+        rust_kw = {'dtype':complex, 'order':'F'}
+        Coupling = RsCoupling
+    else:
+        rust_kw = {}
+        Coupling = PyCoupling
+
     q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
 
     # Single site
-    rotations = [np.eye(3, dtype=complex, order='F')]
+    rotations = [np.eye(3, **rust_kw)]
     magnitudes = np.array([1.0])  # spin-1
-    couplings = [Coupling(0, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=np.array([0., 1., 0.])),
-                 Coupling(0, 0, np.eye(3, dtype=complex, order='F'), inter_site_vector=np.array([0., -1., 0.])), ]
+    couplings = [Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
+                 Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])), ]
 
     return (rotations, magnitudes, q_vectors, couplings)
 
@@ -27,8 +39,11 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
 
     n_q = 100
-    structure = heisenberg_ferromagnet(n_q)
+    use_rust = ("py" not in sys.argv[1]) if len(sys.argv) > 1 else RUST_AVAILABLE
+    spinwave_calculation = rs_spinwave if use_rust else py_spinwave
     q_mags = np.linspace(0, 1, n_q)
+
+    structure = heisenberg_ferromagnet(n_q, rust=use_rust)
     energies = spinwave_calculation(*structure)
 
     # Note: we get complex data types with real part zero

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -5,23 +5,14 @@ See https://spinw.org/tutorials/05tutorial.
 import sys
 
 import numpy as np
+from pyspinw.calculations.spinwave import Coupling as PyCoupling
 
-try:
-    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
-    RUST_AVAILABLE = True
-except ModuleNotFoundError:
-    RUST_AVAILABLE = False
+from examples.raw_calculations.utils import run_example
 
-from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
-
-def kagome_ferromagnet(n_q = 100, rust = False):
+def kagome_ferromagnet(n_q = 100, coupling_class = PyCoupling):
     """Basic ferromagnet on a kagome lattice."""
-    if rust:
-        rust_kw = {'dtype':complex, 'order':'F'}
-        Coupling = RsCoupling
-    else:
-        rust_kw = {}
-        Coupling = PyCoupling
+    rust_kw = {'dtype':complex, 'order':'F'}
+    Coupling = coupling_class
 
     # Three sites, otherwise identical
     rotations = [np.eye(3, **rust_kw) for _ in range(3)]
@@ -74,16 +65,17 @@ if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
 
+    if len(sys.argv) > 1:
+        use_rust = "py" not in sys.argv[1]
+    else:
+        use_rust = True
+
+    structure, energies = run_example(kagome_ferromagnet, use_rust)
+
     indices = np.arange(201)
-
     label_indices = [0, 100, 200]
-
-    use_rust = ("py" not in sys.argv[1]) if len(sys.argv) > 1 else RUST_AVAILABLE
-    spinwave_calculation = rs_spinwave if use_rust else py_spinwave
-
-    rotations, magnitudes, q_vectors, couplings = kagome_ferromagnet(100, rust=use_rust)
+    q_vectors = structure[2]
     labels = [str(q_vectors[idx,:]) for idx in label_indices]
-    energies = spinwave_calculation(rotations, magnitudes, q_vectors, couplings)
 
     plt.plot(indices, np.real(energies))
     # plt.plot(indices, [method.value for method in result.method])

--- a/examples/raw_calculations/utils.py
+++ b/examples/raw_calculations/utils.py
@@ -1,0 +1,63 @@
+"""Utility functions for the raw calculation examples."""
+
+from typing import Callable
+
+from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
+
+
+def run_example(
+    example: Callable[[int, object], tuple[list, "np.array", "np.array", list]], use_rust=False
+) -> (tuple, "np.array"):
+    """Run an example.
+
+    Parameters
+    ----------
+    example: Callable
+        A function which takes two arguments:
+
+        - n_q: the number of q-values to calculate for
+        - coupling_class: the class to use for coupling objects
+
+        and returns four objects:
+
+        - a list of rotations;
+        - an array of magnitudes;
+        - an array of q-vectors;
+        - a list of couplings.
+
+    use_rust: bool
+        Whether to use the Rust calculation routine.
+
+    Returns
+    -------
+    structure: tuple
+        The structure from the example callable.
+    energies: np.array
+        The result from the spinwave calculation.
+
+    """
+    try:
+        from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
+
+        RUST_AVAILABLE = True
+    except ModuleNotFoundError:
+        RUST_AVAILABLE = False
+
+    # default to Python unless Rust is requested (which it is by default) and available
+    coupling_class = PyCoupling
+    spinwave_calculation = py_spinwave
+    if use_rust:
+        if RUST_AVAILABLE:
+            coupling_class = RsCoupling
+            spinwave_calculation = rs_spinwave
+        else:
+            print(
+                "Attempted to run example in Rust, but Rust is not available. "
+                "To run in Python and hide this warning, "
+                "pass 'python' as an argument to the Python script in the terminal."
+            )
+
+    structure = example(coupling_class=coupling_class)
+    energies = spinwave_calculation(*structure)
+
+    return structure, energies

--- a/tests/test_calc_impls.py
+++ b/tests/test_calc_impls.py
@@ -10,11 +10,11 @@ import numpy as np
 import pytest
 
 try:
-    from pyspinw.rust import spinwave_calculation as rs_spinwave
+    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
 except ImportError:
     pytestmark = pytest.mark.skip("Rust module not installed.")
 
-from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave
+from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
 
 from examples.raw_calculations.ferromagnetic_chain import heisenberg_ferromagnet
 from examples.raw_calculations.antiferro_chain import antiferro_chain
@@ -30,7 +30,8 @@ from examples.raw_calculations.kagome_supercell import kagome_supercell
                           kagome_supercell,])
 def test_calc_impls(example):
     """Compare Rust and Python spinwave calculation implementations."""
-    rs_results = rs_spinwave(*example(rust=True))
-    py_results = py_spinwave(*example(rust=False))
+    rs_results = rs_spinwave(*example(coupling_class=RsCoupling))
+    py_results = py_spinwave(*example(coupling_class=PyCoupling))
 
-    np.testing.assert_allclose(np.sort(rs_results), np.sort(py_results))
+    # we test to an absolute tolerance of 1e-6 in line with the MATLAB
+    np.testing.assert_allclose(np.sort(rs_results), np.sort(py_results), atol=1e-6, rtol=0)

--- a/tests/test_calc_impls.py
+++ b/tests/test_calc_impls.py
@@ -1,0 +1,36 @@
+"""Compare spinwave calculation implementations.
+
+This file checks that the the Python and Rust implementations of
+the spinwave calculation both return the same results for a set
+of examples.
+
+"""
+
+import numpy as np
+import pytest
+
+try:
+    from pyspinw.rust import spinwave_calculation as rs_spinwave
+except ImportError:
+    pytestmark = pytest.mark.skip("Rust module not installed.")
+
+from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave
+
+from examples.raw_calculations.ferromagnetic_chain import heisenberg_ferromagnet
+from examples.raw_calculations.antiferro_chain import antiferro_chain
+from examples.raw_calculations.kagome import kagome_ferromagnet
+from examples.raw_calculations.kagome_antiferro import kagome_antiferromagnet
+from examples.raw_calculations.kagome_supercell import kagome_supercell
+
+@pytest.mark.parametrize("example",
+                         [heisenberg_ferromagnet,
+                          antiferro_chain,
+                          kagome_ferromagnet,
+                          kagome_antiferromagnet,
+                          kagome_supercell,])
+def test_calc_impls(example):
+    """Compare Rust and Python spinwave calculation implementations."""
+    rs_results = rs_spinwave(*example(rust=True))
+    py_results = py_spinwave(*example(rust=False))
+
+    np.testing.assert_allclose(np.sort(rs_results), np.sort(py_results))


### PR DESCRIPTION
This PR makes the examples more flexible:
- adds a `rust` option to the example structures which selects which language to use for the couplings.
- adds an option where if "py" (or "python", etc.) is given as an argument to an example it'll run in Python instead of Rust
- adds a unit test that compares the Rust and Python implementations (currently freezes, see #58)

Fixes #63 