### PR TITLE
Adds CI to test compiled code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,10 @@
 name: Lint
 
-on: [push, pull_request, workflow_dispatch]
-
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -1,0 +1,29 @@
+name: Rust tests
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Set up Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+    - name: Install package and dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-test.txt
+        pip install -r requirements.txt
+        pip install . -v
+    - name: Run tests with pytest
+      run: | 
+        # `pytest -m rust` only runs tests decorated @pytest.mark.rust
+        python -m pytest -m rust 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -26,4 +26,6 @@ jobs:
     - name: Run tests with pytest
       run: | 
         # `pytest -m rust` only runs tests decorated @pytest.mark.rust
-        python -m pytest -m rust 
+        # `--runxfail` means 'expect xfail tests to pass' - the Rust tests
+        # are set to xfail if the Rust module is not available
+        python -m pytest --runxfail -m rust 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -1,6 +1,10 @@
 name: Rust tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -28,8 +28,15 @@ jobs:
         pip install -r requirements.txt
         pip install . -v
     - name: Run tests with pytest
-      run: | 
+      run: |
+        # go back a directory so it uses the installed pyspinw
+        # rather than the local repo folder
+        # and get the examples which need to be local
+        # TODO: better package structure so we don't
+        # have to do this
+        cd ..
+        cp -r pySpinW/examples .
         # `pytest -m rust` only runs tests decorated @pytest.mark.rust
         # `--runxfail` means 'expect xfail tests to pass' - the Rust tests
         # are set to xfail if the Rust module is not available
-        python -m pytest --runxfail -m rust 
+        python -m pytest pySpinW/tests --runxfail -m rust 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -26,17 +26,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-test.txt
         pip install -r requirements.txt
-        pip install . -v
+        pip install -e . -v
     - name: Run tests with pytest
       run: |
-        # go back a directory so it uses the installed pyspinw
-        # rather than the local repo folder
-        # and get the examples which need to be local
-        # TODO: better package structure so we don't
-        # have to do this
-        cd ..
-        cp -r pySpinW/examples .
         # `pytest -m rust` only runs tests decorated @pytest.mark.rust
         # `--runxfail` means 'expect xfail tests to pass' - the Rust tests
         # are set to xfail if the Rust module is not available
-        python -m pytest pySpinW/tests --runxfail -m rust 
+        python -m pytest --runxfail -m rust 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,10 @@ ignore = ["D105",  # Missing docstring in magic method (we know what magic metho
           "D213",  # multi-line summary starts at second line
           "PLR",  # pylint refactor suggestions
           ]
+
+
+[tool.pytest.ini_options]
+markers = [
+    "rust: marks tests that require the compiled Rust code",
+]
+

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -71,7 +71,7 @@ def spinwave_calculation(rotations: list[np.ndarray],
     if PARALLEL:
         # Linear algebra routines in numpy are already parallelised and usually use 4 cores
         # for a single process, so we want to reduce contention by using fewer processes.
-        n_proc = int(np.floor(multiprocessing.cpu_count() / 4))
+        n_proc = max(int(np.floor(multiprocessing.cpu_count() / 4)), 1)
         with ProcessPoolExecutor() as executor:
             q_calculations = [executor.submit(_calc_q_chunks, q, C, n_sites, z, spin_coefficients, couplings)
                               for q in _get_q_chunks(q_vectors, n_proc)]

--- a/tests/test_calc_impls.py
+++ b/tests/test_calc_impls.py
@@ -12,7 +12,9 @@ import pytest
 try:
     from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
 except ImportError:
-    pytestmark = pytest.mark.skip("Rust module not installed.")
+    # we can use the --runxfail option for pytest to then ensure
+    # that the Rust tests run and pass if we're expecting Rust to be installed
+    pytestmark = pytest.mark.xfail(raises=NameError, reason="Rust module not installed.")
 
 from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
 

--- a/tests/test_calc_impls.py
+++ b/tests/test_calc_impls.py
@@ -22,6 +22,7 @@ from examples.raw_calculations.kagome import kagome_ferromagnet
 from examples.raw_calculations.kagome_antiferro import kagome_antiferromagnet
 from examples.raw_calculations.kagome_supercell import kagome_supercell
 
+@pytest.mark.rust
 @pytest.mark.parametrize("example",
                          [heisenberg_ferromagnet,
                           antiferro_chain,


### PR DESCRIPTION
**Note: this PR sits on top of #64, not main!**

This PR adds a workflow to test the Rust code in CI. Fixes #68 and also fixes a small bug I spotted where the Python calculation gives a divide by zero error if there are fewer than 4 processes:
```python
n_proc = int(np.floor(multiprocessing.cpu_count() / 4))
# some lines... then in _get_q_chunks
int(np.floor(q_vectors.shape[0] / n_proc))
```
to fix this, I've just replaced the definition of n_proc with
```python
n_proc = max(int(np.floor(multiprocessing.cpu_count() / 4)), 1)
```