### PR TITLE
Adds Zeeman (external field) term to calculation

### DIFF
--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -5,17 +5,16 @@ See https://spinw.org/tutorials/02tutorial
 import sys
 
 import numpy as np
-from pyspinw.calculations.spinwave import Coupling as PyCoupling
 
-from examples.raw_calculations.utils import run_example
+from examples.raw_calculations.utils import run_example, py_classes
 
-def antiferro_chain(n_q = 100, coupling_class = PyCoupling):
+def antiferro_chain(n_q = 100, classes = py_classes):
     """Antiferromagnetic chain.
 
     We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
     """
     rust_kw = {'dtype':complex, 'order':'F'}
-    Coupling = coupling_class
+    Coupling = classes.coupling
 
     rotations = [np.eye(3, **rust_kw), np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], **rust_kw)]
     magnitudes = np.array([1.0]*2)

--- a/examples/raw_calculations/antiferro_ef.py
+++ b/examples/raw_calculations/antiferro_ef.py
@@ -1,0 +1,66 @@
+"""Example of an antiferromagnetic chain with an external magnetic field.
+
+Based on the (currently unpublished) spinW Tutorial 29:
+https://github.com/SpinW/spinw/blob/dc06a4bec2c44bcfde6baa630ecb6329fb4b68ba/tutorials/tutorial/tutorial29.m
+"""
+import sys
+
+import numpy as np
+from pyspinw.calculations.spinwave import Coupling as PyCoupling, MagneticField as PyField
+
+from examples.raw_calculations.utils import run_example
+
+def antiferro_ef(n_q = 100, coupling_class = PyCoupling, field_class = PyField):
+    """Antiferromagnetic chain.
+
+    We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
+    """
+    rust_kw = {'dtype':complex, 'order':'F'}
+    Coupling = coupling_class
+    MagneticField = field_class
+
+    rotations = [np.eye(3, **rust_kw), np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], **rust_kw)]
+    magnitudes = np.array([1.0]*2)
+
+    aniso_array = np.diag(np.array([0., 0., -0.1], **rust_kw))
+
+    couplings = [
+        # bonds
+        Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
+        Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])),
+        Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
+        Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])),
+        # anisotropies
+        Coupling(0, 0, aniso_array, inter_site_vector=np.array([0., 0., 0.])),
+        Coupling(1, 1, aniso_array, inter_site_vector=np.array([0., 0., 0.])),
+    ]
+
+    g_tensors = [np.eye(3, **rust_kw) * 2] * 2
+
+    ext_field = MagneticField(vector=np.array([0., 0., 7.], **rust_kw),
+                              g_tensors=g_tensors)
+
+    q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
+    q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
+
+    return (rotations, magnitudes, q_vectors, couplings, ext_field)
+
+if __name__ == "__main__":
+
+    import matplotlib.pyplot as plt
+
+    if len(sys.argv) > 1:
+        use_rust = "py" not in sys.argv[1]
+    else:
+        use_rust = True
+
+    _, energies = run_example(antiferro_ef, use_rust, has_field=True)
+
+
+    # Note: we get complex data types with real part zero
+
+    plt.plot(np.linspace(0, 1, 100).reshape(-1, 1), energies)
+
+    #plt.savefig("fig.png")
+    # Compare with tutorial 2, second last figure (https://spinw.org/tutorial2_05.png)
+    plt.show()

--- a/examples/raw_calculations/antiferro_ef.py
+++ b/examples/raw_calculations/antiferro_ef.py
@@ -6,18 +6,17 @@ https://github.com/SpinW/spinw/blob/dc06a4bec2c44bcfde6baa630ecb6329fb4b68ba/tut
 import sys
 
 import numpy as np
-from pyspinw.calculations.spinwave import Coupling as PyCoupling, MagneticField as PyField
 
-from examples.raw_calculations.utils import run_example
+from examples.raw_calculations.utils import run_example, py_classes
 
-def antiferro_ef(n_q = 100, coupling_class = PyCoupling, field_class = PyField):
-    """Antiferromagnetic chain.
+def antiferro_ef(n_q = 100, classes = py_classes):
+    """Antiferromagnetic chain with external magnetic field.
 
     We use a 2x1x1 supercell to capture the magnetic rotation periodicity.
     """
     rust_kw = {'dtype':complex, 'order':'F'}
-    Coupling = coupling_class
-    MagneticField = field_class
+    Coupling = classes.coupling
+    MagneticField = classes.field
 
     rotations = [np.eye(3, **rust_kw), np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], **rust_kw)]
     magnitudes = np.array([1.0]*2)
@@ -54,7 +53,7 @@ if __name__ == "__main__":
     else:
         use_rust = True
 
-    _, energies = run_example(antiferro_ef, use_rust, has_field=True)
+    _, energies = run_example(antiferro_ef, use_rust)
 
 
     # Note: we get complex data types with real part zero

--- a/examples/raw_calculations/benchmark.py
+++ b/examples/raw_calculations/benchmark.py
@@ -2,24 +2,28 @@
 
 from examples.raw_calculations.ferromagnetic_chain import heisenberg_ferromagnet
 from examples.raw_calculations.antiferro_chain import antiferro_chain
+from examples.raw_calculations.antiferro_ef import antiferro_ef
 from examples.raw_calculations.kagome import kagome_ferromagnet
 from examples.raw_calculations.kagome_antiferro import kagome_antiferromagnet
 from examples.raw_calculations.kagome_supercell import kagome_supercell
+from examples.raw_calculations.utils import InternalClasses, py_classes
 
 from prettytable import PrettyTable
 from timeit import timeit
 
 try:
-    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
+    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling, MagneticField as RsField
+    rs_classes = InternalClasses(coupling=RsCoupling, field=RsField)
     RUST_AVAILABLE = True
 except ModuleNotFoundError:
     RUST_AVAILABLE = False
 
-from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
+from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave
 
 examples = [
     "heisenberg_ferromagnet",
     "antiferro_chain",
+    "antiferro_ef",
     "kagome_ferromagnet",
     "kagome_antiferromagnet",
     "kagome_supercell",
@@ -30,10 +34,10 @@ rust_option = [False, True] if RUST_AVAILABLE else [False]
 for use_rust in rust_option:
     if use_rust:
         spinwave_calculation = "rs_spinwave"
-        coupling_class = "RsCoupling"
+        classes = "rs_classes"
     else:
         spinwave_calculation = "py_spinwave"
-        coupling_class = "PyCoupling"
+        classes = "py_classes"
 
     table = PrettyTable()
     table.field_names = ["n_q"] + examples
@@ -44,7 +48,7 @@ for use_rust in rust_option:
             times.append(
                 timeit(
                     f"{spinwave_calculation}(*structure)",
-                    setup=f"structure = {example}(n_q={n_q}, coupling_class = {coupling_class})",
+                    setup=f"structure = {example}(n_q={n_q}, classes={classes})",
                     globals=globals(),
                     number=10,
                 )

--- a/examples/raw_calculations/ferromagnet_gtensor.py
+++ b/examples/raw_calculations/ferromagnet_gtensor.py
@@ -1,0 +1,73 @@
+"""Basic Heisenberg ferromagnetic chain with magnetic field and g-tensor specified.
+
+Equivalent MATLAB code:
+```
+% spin chain
+FMchain = spinw;
+FMchain.genlattice('lat_const',[3 8 8],'angled',[90 90 90])
+FMchain.addatom('r', [0 0 0],'S', 1,'label','MCu1','color','blue')
+
+% magnetic structure
+FMchain.gencoupling('maxDistance',7)
+FMchain.addmatrix('value',-eye(3),'label','Ja','color','green')
+FMchain.addcoupling('mat','Ja','bond',1);
+FMchain.genmagstr('mode','direct', 'k',[0 0 0],'n',[1 0 0],'S',[0; 1; 0]);
+
+% magnetic field
+FMchain.field([5 10 15]);
+gmat = ones(3) + diag([1 2 3]);
+FMchain.addmatrix('label', 'g0', 'value', gmat);
+FMchain.addg('g0')
+
+% create spectrum and plot
+FMspec = FMchain.spinwave({[0 0 0] [1 0 0]},'hermit',false,'gtensor',true);
+sw_plotspec(FMspec)
+```
+"""
+import sys
+
+import numpy as np
+
+from examples.raw_calculations.utils import run_example, py_classes
+
+def ferromagnet_gtensor(n_q = 100, classes = py_classes):
+    """Basic ferromagnet with magnetic field and g-tensor."""
+    rust_kw = {'dtype':complex, 'order':'F'}
+    Coupling = classes.coupling
+    MagneticField = classes.field
+
+    q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
+    q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
+
+    # external field
+    g_tensor = [np.array([[2., 1., 1.],
+                          [1., 3., 1.],
+                          [1., 1., 4.]], **rust_kw)]
+    ext_field = MagneticField(vector=np.array([5., 10., 15.], **rust_kw), g_tensors=g_tensor)
+
+    # Single site
+    rotations = [np.eye(3, **rust_kw)]
+    magnitudes = np.array([1.0])  # spin-1
+    couplings = [Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
+                 Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])), ]
+
+    return (rotations, magnitudes, q_vectors, couplings, ext_field)
+
+if __name__ == "__main__":
+
+    import matplotlib.pyplot as plt
+
+    if len(sys.argv) > 1:
+        use_rust = "py" not in sys.argv[1]
+    else:
+        use_rust = True
+
+    q_mags = np.linspace(0, 1, 100)
+
+    _, energies = run_example(ferromagnet_gtensor, use_rust)
+
+    # Note: we get complex data types with real part zero
+    plt.plot(q_mags, energies)
+
+    # Compare with tutorial 1, 3rd last figure (https://spinw.org/tutorial1_05.png)
+    plt.show()

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -5,14 +5,13 @@ See https://spinw.org/tutorials/01tutorial
 import sys
 
 import numpy as np
-from pyspinw.calculations.spinwave import Coupling as PyCoupling
 
-from examples.raw_calculations.utils import run_example
+from examples.raw_calculations.utils import run_example, py_classes
 
-def heisenberg_ferromagnet(n_q = 100, coupling_class = PyCoupling):
+def heisenberg_ferromagnet(n_q = 100, classes = py_classes):
     """Basic ferromagnet."""
     rust_kw = {'dtype':complex, 'order':'F'}
-    Coupling = coupling_class
+    Coupling = classes.coupling
 
     q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -5,14 +5,13 @@ See https://spinw.org/tutorials/05tutorial.
 import sys
 
 import numpy as np
-from pyspinw.calculations.spinwave import Coupling as PyCoupling
 
-from examples.raw_calculations.utils import run_example
+from examples.raw_calculations.utils import run_example, py_classes
 
-def kagome_ferromagnet(n_q = 100, coupling_class = PyCoupling):
+def kagome_ferromagnet(n_q = 100, classes = py_classes):
     """Basic ferromagnet on a kagome lattice."""
     rust_kw = {'dtype':complex, 'order':'F'}
-    Coupling = coupling_class
+    Coupling = classes.coupling
 
     # Three sites, otherwise identical
     rotations = [np.eye(3, **rust_kw) for _ in range(3)]

--- a/examples/raw_calculations/kagome_antiferro.py
+++ b/examples/raw_calculations/kagome_antiferro.py
@@ -5,9 +5,8 @@ See https://spinw.org/tutorials/07tutorial.
 import sys
 
 import numpy as np
-from pyspinw.calculations.spinwave import Coupling as PyCoupling
 
-from examples.raw_calculations.utils import run_example
+from examples.raw_calculations.utils import run_example, py_classes
 
 # define our rotation matrices
 def rotation(theta):
@@ -37,7 +36,7 @@ def rotation(theta):
         dtype=complex, order='F',
     )
 
-def kagome_antiferromagnet(n_q = 100, coupling_class = PyCoupling):
+def kagome_antiferromagnet(n_q = 100, classes = py_classes):
     """Kagome anti-ferromagnet like in tutorial 7."""
     # Three sites, otherwise identical
     rotations = [
@@ -48,7 +47,7 @@ def kagome_antiferromagnet(n_q = 100, coupling_class = PyCoupling):
     magnitudes = np.array([1.0]*3)  # spin-1
 
     rust_kw = {'dtype':complex, 'order':'F'}
-    Coupling = coupling_class
+    Coupling = classes.coupling
 
     # Do the J1 (nearest neighbour) couplings - using table from Matlab Tutorial 7
     # Run the example until the end and then run:

--- a/examples/raw_calculations/kagome_supercell.py
+++ b/examples/raw_calculations/kagome_supercell.py
@@ -6,9 +6,8 @@ This is the magnet in MATLAB SpinW tutorial 8:
 import sys
 
 import numpy as np
-from pyspinw.calculations.spinwave import Coupling as PyCoupling
 
-from examples.raw_calculations.utils import run_example
+from examples.raw_calculations.utils import run_example, py_classes
 
 # define our rotation matrices
 def rotation(theta):
@@ -23,10 +22,10 @@ def rotation(theta):
     )
 
 
-def kagome_supercell(n_q = 100, coupling_class = PyCoupling):
+def kagome_supercell(n_q = 100, classes = py_classes):
     """A sqrt(3) x sqrt(3) Kagome antiferromagnet supercell lattice."""
     rust_kw = {'dtype':complex, 'order':'F'}
-    Coupling = coupling_class
+    Coupling = classes.coupling
 
 
     # we index the supercell by indexing each unit cell in order: so that the

--- a/pyspinw/constants.py
+++ b/pyspinw/constants.py
@@ -1,0 +1,4 @@
+"""Mathematical constants used by pySpinW."""
+
+# Bohr magneton in units meV/T
+MU_B = 0.05788382

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,13 @@
+/// Mathematical constants used in the routines.
+use faer::Scale;
+
+use crate::C64;
+
+// for convenience
+// `Scale` is the faer scalar type used for matrix-scalar multiplication
+pub static J: C64 = C64::new(0., 1.);
+pub static SCALAR_J: Scale<C64> = Scale(J);
+
+// Bohr magneton in units meV/T
+pub static MU_B: f64 = 0.05788382;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,10 @@ use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArray2, ToPyArray};
 use pyo3::prelude::*;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-pub mod spinwave;
+mod spinwave;
 use crate::spinwave::calc_spinwave;
+
+mod constants;
 
 // convenience type for complex arithmetic
 type C64 = Complex<f64>;

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -1,15 +1,11 @@
 use std::f64::consts::PI;
 
-use faer::{unzip, zip, Col, ColRef, Mat, MatRef, Scale, Side};
+use faer::{unzip, zip, Col, ColRef, Mat, MatRef, Side};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{Coupling, MagneticField, C64};
+use crate::constants::{J, SCALAR_J, MU_B};
 
-// for convenience
-// `Scale` is the faer scalar type used for matrix-scalar multiplication
-static J: C64 = C64::new(0., 1.);
-static SCALAR_J: Scale<C64> = Scale(J);
-static MU_B: f64 = 0.05788382;
 
 /// Run the main calculation step for a spinwave calculation.
 #[allow(non_snake_case)]
@@ -47,7 +43,7 @@ pub fn calc_spinwave(
             f.g_tensors
                 .into_iter()
                 .enumerate()
-                .map(|(i, t)| -0.5 * MU_B * f.vector.transpose() * t * etas[i].clone())
+                .map(|(i, t)| -0.5 * MU_B * f.vector.transpose() * t * etas[i])
                 .collect(),
         ),
         None => None,

--- a/tests/test_calc_impls.py
+++ b/tests/test_calc_impls.py
@@ -22,6 +22,7 @@ except ImportError:
 from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling, MagneticField as PyField
 
 from examples.raw_calculations.ferromagnetic_chain import heisenberg_ferromagnet
+from examples.raw_calculations.ferromagnet_gtensor import ferromagnet_gtensor
 from examples.raw_calculations.antiferro_chain import antiferro_chain
 from examples.raw_calculations.antiferro_ef import antiferro_ef
 from examples.raw_calculations.kagome import kagome_ferromagnet
@@ -31,6 +32,7 @@ from examples.raw_calculations.kagome_supercell import kagome_supercell
 @pytest.mark.rust
 @pytest.mark.parametrize("example",
                          [heisenberg_ferromagnet,
+                          ferromagnet_gtensor,
                           antiferro_chain,
                           antiferro_ef,
                           kagome_ferromagnet,

--- a/tests/test_calc_impls.py
+++ b/tests/test_calc_impls.py
@@ -9,17 +9,21 @@ of examples.
 import numpy as np
 import pytest
 
+from examples.raw_calculations.utils import py_classes, InternalClasses
+
 try:
-    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling
+    from pyspinw.rust import spinwave_calculation as rs_spinwave, Coupling as RsCoupling, MagneticField as RsField
+    rs_classes = InternalClasses(coupling=RsCoupling, field=RsField)
 except ImportError:
     # we can use the --runxfail option for pytest to then ensure
     # that the Rust tests run and pass if we're expecting Rust to be installed
     pytestmark = pytest.mark.xfail(raises=NameError, reason="Rust module not installed.")
 
-from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling
+from pyspinw.calculations.spinwave import spinwave_calculation as py_spinwave, Coupling as PyCoupling, MagneticField as PyField
 
 from examples.raw_calculations.ferromagnetic_chain import heisenberg_ferromagnet
 from examples.raw_calculations.antiferro_chain import antiferro_chain
+from examples.raw_calculations.antiferro_ef import antiferro_ef
 from examples.raw_calculations.kagome import kagome_ferromagnet
 from examples.raw_calculations.kagome_antiferro import kagome_antiferromagnet
 from examples.raw_calculations.kagome_supercell import kagome_supercell
@@ -28,13 +32,14 @@ from examples.raw_calculations.kagome_supercell import kagome_supercell
 @pytest.mark.parametrize("example",
                          [heisenberg_ferromagnet,
                           antiferro_chain,
+                          antiferro_ef,
                           kagome_ferromagnet,
                           kagome_antiferromagnet,
                           kagome_supercell,])
 def test_calc_impls(example):
     """Compare Rust and Python spinwave calculation implementations."""
-    rs_results = rs_spinwave(*example(coupling_class=RsCoupling))
-    py_results = py_spinwave(*example(coupling_class=PyCoupling))
+    rs_results = rs_spinwave(*example(classes=rs_classes))
+    py_results = py_spinwave(*example(classes=py_classes))
 
     # we test to an absolute tolerance of 1e-6 in line with the MATLAB
     np.testing.assert_allclose(np.sort(rs_results), np.sort(py_results), atol=1e-6, rtol=0)


### PR DESCRIPTION
This PR makes it possible to provide an external magnetic field to the calculation. This is done via a new dataclass called MagneticField which contains a `vector` and a `g_tensor` list of arrays. Fixes #72 

This PR also adds two examples:
- `antiferro_ef.py`, which is [tutorial 29](https://github.com/SpinW/spinw/blob/dc06a4bec2c44bcfde6baa630ecb6329fb4b68ba/tutorials/tutorial/tutorial29.m) for MATLAB spinW. This is the antiferro chain with added anisotropies and an external magnetic field applied.
- `ferromagnet_gtensor.py`, an example for a simple ferromagnetic chain with an explicit field and g-tensor specified.