### PR TITLE
Updated rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ name = "rust"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = {version="0.23.3", features=["num-complex"]}
-numpy = "0.23.0"
-faer = "0.22.6"
-faer-ext = {version="0.6.0", features=["numpy"]}
+pyo3 = {version="0.26", features=["num-complex"]}
+numpy = "0.26.0"
+faer = "0.23.1"
+faer-ext = {version="0.7.1", features=["numpy"]}
 num-complex = "0.4.6"
-rayon = "1.10.0"
+rayon = "1.11.0"


### PR DESCRIPTION
Small PR just to update Rust dependencies to their latest versions. This fixes a (not relevant to us) security issue that Dependabot keeps bugging me about.