### PR TITLE
Replaces `faer` `concat!` macro with block Hamiltonian function and makes minor refactors to the Rust code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub fn spinwave_calculation<'py>(
     couplings: Vec<Py<Coupling>>,
 ) -> PyResult<Vec<Bound<'py, PyArray1<f64>>>> {
     // convert PyO3-friendly array types to faer matrices
-    let r: Vec<MatRef<C64>> = rotations.into_iter().map(|m| m.into_faer()).collect();
+    let r: Vec<MatRef<C64>> = rotations.into_iter().map(faer_ext::IntoFaer::into_faer).collect();
     let qv = q_vectors.into_par_iter().map(Col::from_iter).collect();
 
     let c = couplings.par_iter().map(pyo3::Py::get).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use faer_ext::IntoFaer;
 use num_complex::Complex;
 use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArray2, ToPyArray};
 use pyo3::prelude::*;
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 pub mod spinwave;
 use crate::spinwave::calc_spinwave;
@@ -53,11 +53,10 @@ pub fn spinwave_calculation<'py>(
 ) -> PyResult<Vec<Bound<'py, PyArray1<f64>>>> {
     // convert PyO3-friendly array types to faer matrices
     let r: Vec<MatRef<C64>> = rotations.into_iter().map(faer_ext::IntoFaer::into_faer).collect();
-    let qv = q_vectors.into_par_iter().map(Col::from_iter).collect();
 
     let c = couplings.par_iter().map(pyo3::Py::get).collect();
 
-    let energies = calc_spinwave(r, magnitudes, qv, c);
+    let energies = calc_spinwave(r, magnitudes, q_vectors, c);
     Ok(energies.into_iter().map(|v| v.to_pyarray(py)).collect())
 }
 

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -16,7 +16,7 @@ static SCALAR_J: Scale<C64> = Scale(J);
 pub fn calc_spinwave(
     rotations: Vec<MatRef<C64>>,
     magnitudes: Vec<f64>,
-    q_vectors: Vec<Col<f64>>,
+    q_vectors: Vec<Vec<f64>>,
     couplings: Vec<&Coupling>,
 ) -> Vec<Vec<f64>> {
     let n_sites = rotations.len();
@@ -49,7 +49,7 @@ pub fn calc_spinwave(
 
     q_vectors
         .into_par_iter()
-        .map(|q| spinwave_single_q(q, &C, n_sites, &z, &spin_coefficients, &couplings))
+        .map(|q| spinwave_single_q(Col::from_iter(q), &C, n_sites, &z, &spin_coefficients, &couplings))
         .collect()
 }
 

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -61,7 +61,7 @@ fn spinwave_single_q(
     n_sites: usize,
     z: &[Col<C64>],
     spin_coefficients: &MatRef<C64>,
-    couplings: &Vec<&Coupling>,
+    couplings: &[&Coupling],
 ) -> Vec<f64> {
     // create A and B matrices for the Hamiltonian
 
@@ -124,6 +124,7 @@ fn spinwave_single_q(
         .expect("Could not calculate eigenvalues of the Hamiltonian.")
 }
 /// Get the components of the rotation matrices for the axis indexed by `index`.
+#[inline]
 fn get_rotation_component(rotations: &Vec<MatRef<C64>>, index: usize) -> Vec<Col<C64>> {
     rotations
         .par_iter()
@@ -132,6 +133,7 @@ fn get_rotation_component(rotations: &Vec<MatRef<C64>>, index: usize) -> Vec<Col
 }
 
 /// Perform componentwise multiplication on two matrices.
+#[inline]
 fn component_mul(a: &Mat<C64>, b: &MatRef<C64>) -> Mat<C64> {
     let mut product = Mat::<C64>::zeros(a.nrows(), a.ncols());
     zip!(&mut product, a, b).for_each(|unzip!(product, x, y)| *product = x * y);
@@ -140,6 +142,7 @@ fn component_mul(a: &Mat<C64>, b: &MatRef<C64>) -> Mat<C64> {
 
 /// Combine the A, B, and C matrices into the Hamiltonian `h(q)` matrix.
 #[allow(non_snake_case)]
+#[inline(always)]
 fn make_block_hamiltonian(A: Mat<C64>, B: Mat<C64>, C: &Mat<C64>) -> Mat<C64> {
     let A_minus_C: Mat<C64> = A.clone() - C;
     let A_conj_minus_C: Mat<C64> = A.adjoint() - C;

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -72,7 +72,6 @@ fn spinwave_single_q(
     A = component_mul(&A, spin_coefficients);
     B = component_mul(&B, spin_coefficients);
 
-    // create Hamiltonian as a block matrix (the stack! macro creates a block matrix)
     let hamiltonian: Mat<C64> = make_block_hamiltonian(A, B, C);
 
     // take square root of Hamiltonian using Cholesky if possible; if this fails,


### PR DESCRIPTION
This PR fixes #77 by replacing the `faer` `concat!` macro, which is not recommended for external use, with a more stable own function implementation. This doesn't significantly change the function runtime:
```
old concat macro:
+------+------------------------+-----------------+--------------------+------------------------+------------------+
| n_q  | heisenberg_ferromagnet | antiferro_chain | kagome_ferromagnet | kagome_antiferromagnet | kagome_supercell |
+------+------------------------+-----------------+--------------------+------------------------+------------------+
| 100  |        0.007045        |     0.006178    |      0.013309      |        0.016799        |     0.194486     |
| 1000 |        0.028488        |     0.029554    |      0.098945      |        0.126499        |     1.914994     |
| 5000 |        0.134682        |     0.141327    |      0.507639      |        0.659204        |    12.774269     |
+------+------------------------+-----------------+--------------------+------------------------+------------------+
new block hamiltonian function:
+------+------------------------+-----------------+--------------------+------------------------+------------------+
| n_q  | heisenberg_ferromagnet | antiferro_chain | kagome_ferromagnet | kagome_antiferromagnet | kagome_supercell |
+------+------------------------+-----------------+--------------------+------------------------+------------------+
| 100  |        0.005785        |     0.005534    |      0.013091      |        0.014965        |     0.189698     |
| 1000 |        0.027250        |     0.030260    |      0.094214      |        0.121221        |     1.879567     |
| 5000 |        0.130085        |     0.144967    |      0.484230      |        0.613518        |    12.258631     |
+------+------------------------+-----------------+--------------------+------------------------+------------------+
```

this PR also makes some minor refactors to the Rust code:
- changes the internal functions to not have a preceding `_` (Rust denotes public functions with the `pub fn` syntax, so this isn't necessary and just makes the code harder to read for no reason)
- adds the #[inline] macro to internal functions (which can create some very minor performance improvements with basically no downside)
- avoids needing to re-iterate over vectors so much by removing an unnecessary iteration in the Python bindings over q-vectors, and combining the 3 calls to `get_rotation_component` into one `get_rotation_components` function
    - the `get_rotation_components` function also now avoids copying the 3rd component of the rotation matrices (eta) when it's only ever read
- changes some Vec's into slices in the single-Q spinwave function, which apparently helps the compiler optimise it...