### PR TITLE
Fix Sab / intensity calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,10 @@ target/
 profile_default/
 ipython_config.py
 
+# Vim
+*.swp
+*.swo
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:

--- a/.gitignore
+++ b/.gitignore
@@ -82,10 +82,6 @@ target/
 profile_default/
 ipython_config.py
 
-# Vim
-*.swp
-*.swo
-
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
@@ -124,9 +120,6 @@ celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
-
-# Old Matlab files for checking
-examples/*/*.m
 
 # Environments
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
+# Old Matlab files for checking
+examples/*/*.m
+
 # Environments
 .env
 .venv
@@ -169,3 +172,6 @@ cython_debug/
 .envrc
 
 Cargo.lock
+
+# Config files
+render_settings.conf

--- a/examples/raw_calculations/antiferro_chain.py
+++ b/examples/raw_calculations/antiferro_chain.py
@@ -16,18 +16,18 @@ def antiferro_chain(n_q = 100, classes = py_classes):
     rust_kw = {'dtype':complex, 'order':'F'}
     Coupling = classes.coupling
 
-    rotations = [np.eye(3, **rust_kw), np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], **rust_kw)]
+    rotations = [np.eye(3, **rust_kw), np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]], **rust_kw)]
     magnitudes = np.array([1.0]*2)
-    positions = np.array([[0., 0., 0.], [0., 1., 0.]])
+    positions = np.array([[0., 0., 0.], [0., 0.5, 0.]])
 
     couplings = [
+        Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 0., 0.])),
         Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
-        Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])),
-        Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
+        Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 0., 0.])),
         Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])),
     ]
 
-    q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
+    q_mags = np.linspace(0, 2, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
 
     return (rotations, magnitudes, q_vectors, couplings, positions)

--- a/examples/raw_calculations/antiferro_ef.py
+++ b/examples/raw_calculations/antiferro_ef.py
@@ -44,7 +44,7 @@ def antiferro_ef(n_q = 100, classes = py_classes):
     q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 2, 0]).reshape(1, 3) * q_mags
 
-    return (rotations, magnitudes, q_vectors, couplings, positions, ext_field)
+    return (rotations, magnitudes, q_vectors, couplings, positions, np.eye(3, order='F'), ext_field)
 
 if __name__ == "__main__":
 

--- a/examples/raw_calculations/antiferro_ef.py
+++ b/examples/raw_calculations/antiferro_ef.py
@@ -21,15 +21,15 @@ def antiferro_ef(n_q = 100, classes = py_classes):
     rotations = [np.eye(3, **rust_kw), np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]], **rust_kw)]
 
     magnitudes = np.array([1.0]*2)
-    positions = np.array([[0., 0., 0.], [0., 1., 0.]])
+    positions = np.array([[0., 0., 0.], [0., 0.5, 0.]])
 
-    aniso_array = np.diag(np.array([0., 0., -0.1], **rust_kw))
+    aniso_array = np.diag(np.array([0., 0., -0.2], **rust_kw))
 
     couplings = [
         # bonds
+        Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 0., 0.])),
         Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
-        Coupling(0, 1, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])),
-        Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
+        Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 0., 0.])),
         Coupling(1, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])),
         # anisotropies
         Coupling(0, 0, aniso_array, inter_site_vector=np.array([0., 0., 0.])),
@@ -38,11 +38,11 @@ def antiferro_ef(n_q = 100, classes = py_classes):
 
     g_tensors = [np.eye(3, **rust_kw) * 2] * 2
 
-    ext_field = MagneticField(vector=np.array([0., 0., 7.], **rust_kw),
+    ext_field = MagneticField(vector=np.array([0., 0., 14.], **rust_kw),
                               g_tensors=g_tensors)
 
     q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
-    q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
+    q_vectors = np.array([0, 2, 0]).reshape(1, 3) * q_mags
 
     return (rotations, magnitudes, q_vectors, couplings, positions, ext_field)
 

--- a/examples/raw_calculations/ferromagnet_gtensor.py
+++ b/examples/raw_calculations/ferromagnet_gtensor.py
@@ -52,7 +52,7 @@ def ferromagnet_gtensor(n_q = 100, classes = py_classes):
     couplings = [Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., 1., 0.])),
                  Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([0., -1., 0.])), ]
 
-    return rotations, magnitudes, q_vectors, couplings, positions, ext_field
+    return rotations, magnitudes, q_vectors, couplings, positions, np.eye(3, order='F'), ext_field
 
 if __name__ == "__main__":
 

--- a/examples/raw_calculations/ferromagnetic_chain.py
+++ b/examples/raw_calculations/ferromagnetic_chain.py
@@ -13,7 +13,7 @@ def heisenberg_ferromagnet(n_q = 100, classes = py_classes):
     rust_kw = {'dtype':complex, 'order':'F'}
     Coupling = classes.coupling
 
-    q_mags = np.linspace(0, 1, n_q).reshape(-1, 1)
+    q_mags = np.linspace(0.01, 0.99, n_q).reshape(-1, 1)
     q_vectors = np.array([0, 1, 0]).reshape(1, 3) * q_mags
     positions = [np.array([0., 0., 0.])]  # single site at origin
 

--- a/examples/raw_calculations/kagome.py
+++ b/examples/raw_calculations/kagome.py
@@ -48,7 +48,7 @@ def kagome_ferromagnet(n_q = 100, classes = py_classes):
                  ]
 
 
-    q_mags = 0.5*np.linspace(0, 1, n_q + 1).reshape(-1, 1)
+    q_mags = 0.5*np.linspace(0.001, 0.999, n_q + 1).reshape(-1, 1)
 
     # q_vectors = np.concatenate((
     #         q_mags[::-1].reshape(-1, 1) * np.array([1, 0, 1]).reshape(1, -1),

--- a/examples/raw_calculations/kagome_antiferro.py
+++ b/examples/raw_calculations/kagome_antiferro.py
@@ -45,9 +45,9 @@ def kagome_antiferromagnet(n_q = 100, classes = py_classes):
         rotation(-2 * np.pi / 3)
     ]
     magnitudes = np.array([1.0]*3)  # spin-1
-    positions = [np.array([0., 0., 0.]),
-                 np.array([1., 0., 0.,]),
-                 np.array([0., 1., 0.]),]
+    positions = [np.array([0.5, 0., 0.]),
+                 np.array([0., 0.5, 0.,]),
+                 np.array([0.5, 0.5, 0.]),]
 
     rust_kw = {'dtype':complex, 'order':'F'}
     Coupling = classes.coupling
@@ -56,7 +56,7 @@ def kagome_antiferromagnet(n_q = 100, classes = py_classes):
     # Run the example until the end and then run:
     # >> AFkagome.table('bond',1:2)
     # And use the values in idx1, idx2, and dl (idx1, idx2 indexed from 1 not 0)
-    J1mat = np.eye(3, **rust_kw) * 1.0
+    J1mat = np.eye(3, **rust_kw) * 0.5
     couplings = [
         Coupling(2, 0, J1mat, np.array([0., 1, 0])),
         Coupling(0, 1, J1mat, np.array([0., -1, 0])),
@@ -76,7 +76,7 @@ def kagome_antiferromagnet(n_q = 100, classes = py_classes):
     ])
 
     # Do the J2 (next-nearest-neigbour) couplings
-    J2mat = np.eye(3, **rust_kw) * 0.11
+    J2mat = np.eye(3, **rust_kw) * 0.055
     couplings.extend([
         Coupling(0, 1, J2mat, np.array([1., -1, 0])),
         Coupling(1, 2, J2mat, np.array([0., 1, 0])),
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     energies = [np.sort(energy.real) for energy in energies]
     positive_energies = [energy[energy>0] for energy in energies]
 
-    plot(indices, plot, sqw)
+    plot(indices, energies, sqw)
 
     # Compare with tutorial 7, 2nd last figure (https://spinw.org/tutorial7_05.png)
     # It looks slightly assymmetric because Matlab-SpinW adjusts the aspect-ratio

--- a/examples/raw_calculations/kagome_supercell.py
+++ b/examples/raw_calculations/kagome_supercell.py
@@ -124,7 +124,8 @@ def kagome_supercell(n_q = 100, classes = py_classes):
         )
     )
 
-    return rotations, magnitudes, q_vectors, couplings, positions
+    rlu2cart = np.sqrt([[1./36, 1./108, 0], [0, 1./27, 0], [0, 0, 1./1600]]) * 2 * np.pi
+    return rotations, magnitudes, q_vectors, couplings, positions, rlu2cart
 
 if __name__ == "__main__":
     import matplotlib.pyplot as plt

--- a/examples/raw_calculations/utils.py
+++ b/examples/raw_calculations/utils.py
@@ -80,11 +80,11 @@ def run_example(
     return structure, energies, sqw
 
 
-def plot(q, energies, sqw):
+def plot(q, energies, sqw, show=True):
     """Plot energies and sqw."""
     import matplotlib.pyplot as plt
 
-    plt.figure(figsize=(8, 6))
+    fg = plt.figure(figsize=(8, 6))
 
     plt.subplot(2, 1, 1)
     plt.plot(q, energies)
@@ -97,4 +97,7 @@ def plot(q, energies, sqw):
     plt.ylabel("S(q,ω) (arb. units)")
 
     plt.tight_layout()
-    plt.show()
+    if show:
+        plt.show()
+    else:
+        return fg

--- a/examples/structures/antiferromagnetic_chain.py
+++ b/examples/structures/antiferromagnetic_chain.py
@@ -35,10 +35,4 @@ if __name__ == "__main__":
     hamiltonian.print_summary()
 
     path = Path([[0,0,0], [1,0,0]])
-    #hamiltonian.energy_plot(path, show_intensities=True)
-    energy, intensities = hamiltonian.energies_and_intensities(path.q_points(), use_rust=False)
-    import matplotlib.pyplot as plt
-    fg, ax = plt.subplots(2, 1)
-    ax[0].plot(energy)
-    ax[1].plot(intensities)
-    plt.show()
+    hamiltonian.energy_plot(path, show_intensities=True)

--- a/examples/structures/antiferromagnetic_chain.py
+++ b/examples/structures/antiferromagnetic_chain.py
@@ -10,6 +10,7 @@ from pyspinw.site import LatticeSite
 from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
+import sys
 
 from pyspinw.debug_plot import debug_plot
 

--- a/examples/structures/antiferromagnetic_chain.py
+++ b/examples/structures/antiferromagnetic_chain.py
@@ -13,13 +13,30 @@ from pyspinw.structures import Structure
 
 from pyspinw.debug_plot import debug_plot
 
+"""
+AFMchain = spinw;
+AFMchain.genlattice('lat_const',[3 8 8],'angled',[90 90 90],'spgr',0);
+AFMchain.addatom('r',[0 0 0],'S',1,'label','MCu1','color','blue');
+AFMchain.gencoupling('maxDistance',7)
+AFMchain.addmatrix('label','Ja','value',1,'color','red');
+AFMchain.addcoupling('mat','Ja','bond',1);
+AFMchain.genmagstr('mode','direct','k',[1/2 0 0],'n',[1 0 0],'S',[0 0; 1 -1;0 0]);
+afcSpec = AFMchain.spinwave({[0 0 0] [1 0 0] 523}, 'hermit',true);
+figure; subplot(2,1,1)
+sw_plotspec(afcSpec,'mode',4,'dE',0.2,'axLim',[0 3])
+afcSpec = sw_egrid(sw_neutron(afcSpec),'Evect',linspace(0,6.5,500),'component','Sperp');
+afcSpec = sw_omegasum(afcSpec,'zeroint',1e-6);
+subplot(2,1,2)
+sw_plotspec(afcSpec,'mode',2,'log',true,'axLim',[-4 10])
+"""
+
 if __name__ == "__main__":
     """Reproduces Tutorial 2: https://spinw.org/tutorials/02tutorial"""
     freeze_support()
 
     unit_cell = UnitCell(3, 8, 8)
 
-    sites = [LatticeSite(0, 0, 0, 0, 0, 1, name="MCu1")]
+    sites = [LatticeSite(0, 0, 0, 0, 1, 0, name="MCu1")]
 
     k = CommensuratePropagationVector(0.5, 0, 0)
     s = Structure(sites, unit_cell=unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
@@ -35,4 +52,4 @@ if __name__ == "__main__":
     hamiltonian.print_summary()
 
     path = Path([[0,0,0], [1,0,0]])
-    hamiltonian.energy_plot(path, show_intensities=True)
+    hamiltonian.plot(path, scale='log')

--- a/examples/structures/antiferromagnetic_chain.py
+++ b/examples/structures/antiferromagnetic_chain.py
@@ -7,33 +7,38 @@ from pyspinw.hamiltonian import Hamiltonian
 from pyspinw.interface import spacegroup, couplings, filter
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
-from pyspinw.symmetry.supercell import TrivialSupercell
+from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 
 from pyspinw.debug_plot import debug_plot
 
 if __name__ == "__main__":
+    """Reproduces Tutorial 2: https://spinw.org/tutorials/02tutorial"""
     freeze_support()
 
-    unit_cell = UnitCell(2,1,1)
+    unit_cell = UnitCell(3, 8, 8)
 
-    sites = [LatticeSite(0, 0, 0, 0,0,1, name="X"),
-             LatticeSite(0.5,0,0, 0,0, -1, name="Y")]
+    sites = [LatticeSite(0, 0, 0, 0, 0, 1, name="MCu1")]
 
-    s = Structure(sites, unit_cell=unit_cell)
-
+    k = CommensuratePropagationVector(0.5, 0, 0)
+    s = Structure(sites, unit_cell=unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
 
     exchanges = couplings(sites=sites,
                           unit_cell=unit_cell,
-                          max_distance=1.1,
+                          max_distance=3.1,
                           coupling_type=HeisenbergCoupling,
-                          j=1,
-                          direction_filter=filter([1,0,0], symmetric=True))
+                          j=1)
 
 
     hamiltonian = Hamiltonian(s, exchanges)
     hamiltonian.print_summary()
 
     path = Path([[0,0,0], [1,0,0]])
-    hamiltonian.energy_plot(path)
+    #hamiltonian.energy_plot(path, show_intensities=True)
+    energy, intensities = hamiltonian.energies_and_intensities(path.q_points(), use_rust=False)
+    import matplotlib.pyplot as plt
+    fg, ax = plt.subplots(2, 1)
+    ax[0].plot(energy)
+    ax[1].plot(intensities)
+    plt.show()

--- a/examples/structures/antiferromagnetic_chain.py
+++ b/examples/structures/antiferromagnetic_chain.py
@@ -34,6 +34,8 @@ if __name__ == "__main__":
     """Reproduces Tutorial 2: https://spinw.org/tutorials/02tutorial"""
     freeze_support()
 
+    use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
+
     unit_cell = UnitCell(3, 8, 8)
 
     sites = [LatticeSite(0, 0, 0, 0, 1, 0, name="MCu1")]
@@ -52,4 +54,4 @@ if __name__ == "__main__":
     hamiltonian.print_summary()
 
     path = Path([[0,0,0], [1,0,0]])
-    hamiltonian.spaghetti_plot(path, scale='log')
+    hamiltonian.spaghetti_plot(path, scale='log', use_rust=use_rust)

--- a/examples/structures/antiferromagnetic_chain.py
+++ b/examples/structures/antiferromagnetic_chain.py
@@ -52,4 +52,4 @@ if __name__ == "__main__":
     hamiltonian.print_summary()
 
     path = Path([[0,0,0], [1,0,0]])
-    hamiltonian.plot(path, scale='log')
+    hamiltonian.spaghetti_plot(path, scale='log')

--- a/examples/structures/antiferromagnetic_chain.py
+++ b/examples/structures/antiferromagnetic_chain.py
@@ -4,7 +4,7 @@ from multiprocessing.spawn import freeze_support
 
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.interface import couplings
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
 from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector
@@ -21,7 +21,8 @@ AFMchain.addatom('r',[0 0 0],'S',1,'label','MCu1','color','blue');
 AFMchain.gencoupling('maxDistance',7)
 AFMchain.addmatrix('label','Ja','value',1,'color','red');
 AFMchain.addcoupling('mat','Ja','bond',1);
-AFMchain.genmagstr('mode','direct','k',[1/2 0 0],'n',[1 0 0],'S',[0 0; 1 -1;0 0]);
+%AFMchain.genmagstr('mode','direct','k',[1/2 0 0],'n',[1 0 0],'S',[0; 1; 0]);
+AFMchain.genmagstr('mode','direct','S',[0 0; 1 -1; 0 0],'nExt',[1 2 1]);
 afcSpec = AFMchain.spinwave({[0 0 0] [1 0 0] 523}, 'hermit',true);
 figure; subplot(2,1,1)
 sw_plotspec(afcSpec,'mode',4,'dE',0.2,'axLim',[0 3])

--- a/examples/structures/antiferromagnetic_chain_with_field.py
+++ b/examples/structures/antiferromagnetic_chain_with_field.py
@@ -1,4 +1,4 @@
-""" Antiferromagnetic chain example """
+""" Antiferromagnetic chain example with applied magnetic field """
 
 from multiprocessing.spawn import freeze_support
 
@@ -14,16 +14,36 @@ from pyspinw.structures import Structure
 
 from pyspinw.debug_plot import debug_plot
 
+"""
+afc = spinw;
+afc.genlattice('lat_const',[4 6 6])
+afc.addatom('r',[  0 0 0],'S',1)
+afc.addatom('r',[1/2 0 0],'S',1)
+afc.addmatrix('label','J','value',1)
+afc.gencoupling
+afc.addcoupling('mat','J','bond',1)
+afc.addmatrix('label','A','value',diag([0 0 -0.1]))
+afc.addaniso('A')
+afc.genmagstr('mode','direct','S',[0 0; 0 0; 1 -1]);
+afc.field([0 0 7])
+afcSpec = afc.spinwave({[0 0 0] [2 0 0] 101}, 'hermit',true);
+figure; subplot(2,1,1)
+sw_plotspec(afcSpec,'mode',4,'dE',0.2,'axLim',[0 3])
+afcSpec = sw_egrid(sw_neutron(afcSpec),'Evect',linspace(0,6.5,500),'component','Sperp');
+afcSpec = sw_omegasum(afcSpec,'zeroint',1e-6);
+subplot(2,1,2)
+sw_plotspec(afcSpec,'mode',2,'log',false,'axLim',[-4 10])
+"""
+
 if __name__ == "__main__":
     freeze_support()
 
-    unit_cell = UnitCell(2,1,1)
+    unit_cell = UnitCell(4,6,6)
 
     sites = [LatticeSite(0, 0, 0, 0,0,1, name="X"),
              LatticeSite(0.5,0,0, 0,0, -1, name="Y")]
 
     s = Structure(sites, unit_cell=unit_cell)
-
 
     exchanges = couplings(sites=sites,
                           unit_cell=unit_cell,
@@ -38,5 +58,5 @@ if __name__ == "__main__":
 
     hamiltonian.print_summary()
 
-    path = Path([[0,0,0], [1,0,0]])
-    hamiltonian.energy_plot(path, field=[0,0,7])
+    path = Path([[0,0,0], [2,0,0]])
+    hamiltonian.plot(path, field=[0,0,7])

--- a/examples/structures/antiferromagnetic_chain_with_field.py
+++ b/examples/structures/antiferromagnetic_chain_with_field.py
@@ -2,18 +2,14 @@
 
 from multiprocessing.spawn import freeze_support
 
-from pyspinw.anisotropy import AxisMagnitudeAnisotropy
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import spacegroup, couplings, filter, axis_anisotropies, axis_anisotropies
+from pyspinw.interface import couplings, filter, axis_anisotropies
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
-from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 import sys
-
-from pyspinw.debug_plot import debug_plot
 
 """
 afc = spinw;

--- a/examples/structures/antiferromagnetic_chain_with_field.py
+++ b/examples/structures/antiferromagnetic_chain_with_field.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
 
     exchanges = couplings(sites=sites,
                           unit_cell=unit_cell,
-                          max_distance=1.1,
+                          max_distance=2.1,
                           coupling_type=HeisenbergCoupling,
                           j=1,
                           direction_filter=filter([1,0,0], symmetric=True))

--- a/examples/structures/antiferromagnetic_chain_with_field.py
+++ b/examples/structures/antiferromagnetic_chain_with_field.py
@@ -38,6 +38,8 @@ sw_plotspec(afcSpec,'mode',2,'log',false,'axLim',[-4 10])
 if __name__ == "__main__":
     freeze_support()
 
+    use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
+
     unit_cell = UnitCell(4,6,6)
 
     sites = [LatticeSite(0, 0, 0, 0,0,1, name="X"),
@@ -59,4 +61,4 @@ if __name__ == "__main__":
     hamiltonian.print_summary()
 
     path = Path([[0,0,0], [2,0,0]])
-    hamiltonian.spaghetti_plot(path, field=[0,0,7])
+    hamiltonian.spaghetti_plot(path, field=[0,0,7], use_rust=use_rust)

--- a/examples/structures/antiferromagnetic_chain_with_field.py
+++ b/examples/structures/antiferromagnetic_chain_with_field.py
@@ -59,4 +59,4 @@ if __name__ == "__main__":
     hamiltonian.print_summary()
 
     path = Path([[0,0,0], [2,0,0]])
-    hamiltonian.plot(path, field=[0,0,7])
+    hamiltonian.spaghetti_plot(path, field=[0,0,7])

--- a/examples/structures/antiferromagnetic_chain_with_field.py
+++ b/examples/structures/antiferromagnetic_chain_with_field.py
@@ -11,6 +11,7 @@ from pyspinw.site import LatticeSite
 from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
+import sys
 
 from pyspinw.debug_plot import debug_plot
 

--- a/examples/structures/ferromagnetic_chain.py
+++ b/examples/structures/ferromagnetic_chain.py
@@ -10,6 +10,7 @@ from pyspinw.site import LatticeSite
 from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
+import sys
 
 if __name__ == "__main__":
     freeze_support()

--- a/examples/structures/ferromagnetic_chain.py
+++ b/examples/structures/ferromagnetic_chain.py
@@ -32,4 +32,4 @@ if __name__ == "__main__":
 
     path = Path([[0,0,0], [1,0,0]])
 
-    hamiltonian.energy_plot(path)
+    hamiltonian.spaghetti_plot(path)

--- a/examples/structures/ferromagnetic_chain.py
+++ b/examples/structures/ferromagnetic_chain.py
@@ -4,10 +4,9 @@ from multiprocessing.spawn import freeze_support
 
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.interface import couplings, filter
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
-from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 import sys
@@ -22,7 +21,6 @@ if __name__ == "__main__":
     only_site = LatticeSite(0, 0, 0, 0,0,1, name="X")
 
     s = Structure([only_site], unit_cell=unit_cell)
-
 
     exchanges = couplings(sites=[only_site],
                           unit_cell=unit_cell,

--- a/examples/structures/ferromagnetic_chain.py
+++ b/examples/structures/ferromagnetic_chain.py
@@ -14,6 +14,8 @@ from pyspinw.structures import Structure
 if __name__ == "__main__":
     freeze_support()
 
+    use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
+
     unit_cell = UnitCell(1,1,1)
 
     only_site = LatticeSite(0, 0, 0, 0,0,1, name="X")
@@ -32,4 +34,4 @@ if __name__ == "__main__":
 
     path = Path([[0,0,0], [1,0,0]])
 
-    hamiltonian.spaghetti_plot(path)
+    hamiltonian.spaghetti_plot(path, use_rust=use_rust)

--- a/examples/structures/kagome_antiferromagnet.py
+++ b/examples/structures/kagome_antiferromagnet.py
@@ -7,7 +7,7 @@ from pyspinw.hamiltonian import Hamiltonian
 from pyspinw.interface import spacegroup, couplings, filter
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
-from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector, TrivialSupercell
+from pyspinw.legacy.genmagstr import genmagstr
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 from numpy import sqrt
@@ -42,12 +42,10 @@ if __name__ == "__main__":
 
     unit_cell = UnitCell(6, 6, 10, gamma=120)
 
-    x = LatticeSite(0.5, 0, 0, 1, 2, 0, name="X", unit="lu")
-    y = LatticeSite(0, 0.5, 0, -2, -1, 0, name="Y", unit="lu")
-    z = LatticeSite(0.5, 0.5, 0, 1, -1, 0, name="Z", unit="lu")
-
-    sites = [x, y, z]
-    s = Structure(sites, unit_cell=unit_cell, supercell=TrivialSupercell(scaling=(1,1,1)))
+    x = LatticeSite(0.5, 0, 0, 1, 2, 0, S=1, name="X")
+    y = LatticeSite(0, 0.5, 0, -2, -1, 0, S=1, name="Y")
+    z = LatticeSite(0.5, 0.5, 0, 1, -1, 0, S=1, name="Z")
+    s = genmagstr([x, y, z], unit_cell, mode='tile', unit='lu')
 
     j1 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=0, max_distance=4.1, coupling_type=HeisenbergCoupling, j=1)
     j2 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=5, max_distance=5.2, coupling_type=HeisenbergCoupling, j=0.11)

--- a/examples/structures/kagome_antiferromagnet.py
+++ b/examples/structures/kagome_antiferromagnet.py
@@ -37,6 +37,8 @@ if __name__ == "__main__":
     """Reproduces Tutorial 7: https://spinw.org/tutorials/07tutorial"""
     freeze_support()
 
+    use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
+
     unit_cell = UnitCell(6, 6, 10, gamma=120)
 
     x = LatticeSite(0.5, 0, 0, 1, 2, 0, name="X", unit="lu")
@@ -58,4 +60,4 @@ if __name__ == "__main__":
     hamiltonian.expand()
 
     path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
-    hamiltonian.spaghetti_plot(path)
+    hamiltonian.spaghetti_plot(path, use_rust=use_rust)

--- a/examples/structures/kagome_antiferromagnet.py
+++ b/examples/structures/kagome_antiferromagnet.py
@@ -42,9 +42,6 @@ if __name__ == "__main__":
     x = LatticeSite(0.5, 0, 0, 1, 2, 0, name="X", unit="lu")
     y = LatticeSite(0, 0.5, 0, -2, -1, 0, name="Y", unit="lu")
     z = LatticeSite(0.5, 0.5, 0, 1, -1, 0, name="Z", unit="lu")
-    #x = LatticeSite(0.5, 0, 0, 0, 1, 0, name="X")
-    #y = LatticeSite(0, 0.5, 0, -sqrt(3)/2, -0.5, 0, name="Y")
-    #z = LatticeSite(0.5, 0.5, 0, sqrt(3)/2, -0.5, 0, name="Z")
 
     sites = [x, y, z]
     s = Structure(sites, unit_cell=unit_cell, supercell=TrivialSupercell(scaling=(1,1,1)))

--- a/examples/structures/kagome_antiferromagnet.py
+++ b/examples/structures/kagome_antiferromagnet.py
@@ -1,0 +1,64 @@
+""" Kagome Antiferromagnet example """
+
+from multiprocessing.spawn import freeze_support
+
+from pyspinw.coupling import HeisenbergCoupling
+from pyspinw.hamiltonian import Hamiltonian
+from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.path import Path
+from pyspinw.site import LatticeSite
+from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector, TrivialSupercell
+from pyspinw.symmetry.unitcell import UnitCell
+from pyspinw.structures import Structure
+from numpy import sqrt
+
+from pyspinw.debug_plot import debug_plot
+
+"""
+AFkagome = spinw;
+AFkagome.genlattice('lat_const',[6 6 10],'angled',[90 90 120],'spgr','P -3')
+AFkagome.addatom('r',[1/2 0 0],'S', 1,'label','MCu1','color','r')
+AFkagome.gencoupling('maxDistance',7)
+AFkagome.addmatrix('label','J1','value',1.00,'color','r')
+AFkagome.addmatrix('label','J2','value',0.11,'color','g')
+AFkagome.addcoupling('mat','J1','bond',1)
+AFkagome.addcoupling('mat','J2','bond',2)
+S0 = [1 -2 1; 2 -1 -1; 0 0 0];
+AFkagome.genmagstr('mode','direct','k',[0 0 0],'n',[0 0 1],'unit','lu','S',S0);
+afkSpec = AFkagome.spinwave({[-1/2 0 0] [0 0 0] [1/2 1/2 0] 100},'hermit',true);
+figure; subplot(211)
+sw_plotspec(afkSpec,'mode',1,'colorbar',false,'colormap',[0 0 0],'dashed',true,'axLim',[0 3])
+afkSpec = sw_egrid(sw_neutron(afkSpec),'Evect',linspace(0,6.5,500),'component','Sperp');
+afkSpec = sw_omegasum(afkSpec,'zeroint',1e-6);
+subplot(212); sw_plotspec(afkSpec,'mode',2,'log',false,'axLim',[0 3])
+"""
+
+if __name__ == "__main__":
+    """Reproduces Tutorial 7: https://spinw.org/tutorials/07tutorial"""
+    freeze_support()
+
+    unit_cell = UnitCell(6, 6, 10, gamma=120)
+
+    x = LatticeSite(0.5, 0, 0, 1, 2, 0, name="X", unit="lu")
+    y = LatticeSite(0, 0.5, 0, -2, -1, 0, name="Y", unit="lu")
+    z = LatticeSite(0.5, 0.5, 0, 1, -1, 0, name="Z", unit="lu")
+    #x = LatticeSite(0.5, 0, 0, 0, 1, 0, name="X")
+    #y = LatticeSite(0, 0.5, 0, -sqrt(3)/2, -0.5, 0, name="Y")
+    #z = LatticeSite(0.5, 0.5, 0, sqrt(3)/2, -0.5, 0, name="Z")
+
+    sites = [x, y, z]
+    s = Structure(sites, unit_cell=unit_cell, supercell=TrivialSupercell(scaling=(1,1,1)))
+
+    j1 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=0, max_distance=4.1, coupling_type=HeisenbergCoupling, j=1)
+    j2 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=5, max_distance=5.2, coupling_type=HeisenbergCoupling, j=0.11)
+    exchanges = j1 + j2
+
+    debug_plot(s, exchanges, show=False)
+
+    hamiltonian = Hamiltonian(s, exchanges)
+
+    hamiltonian.print_summary()
+    hamiltonian.expand()
+
+    path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
+    hamiltonian.plot(path)

--- a/examples/structures/kagome_antiferromagnet.py
+++ b/examples/structures/kagome_antiferromagnet.py
@@ -58,4 +58,4 @@ if __name__ == "__main__":
     hamiltonian.expand()
 
     path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
-    hamiltonian.plot(path)
+    hamiltonian.spaghetti_plot(path)

--- a/examples/structures/kagome_antiferromagnet.py
+++ b/examples/structures/kagome_antiferromagnet.py
@@ -4,16 +4,13 @@ from multiprocessing.spawn import freeze_support
 
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.interface import couplings
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
 from pyspinw.legacy.genmagstr import genmagstr
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
-from numpy import sqrt
 import sys
-
-from pyspinw.debug_plot import debug_plot
 
 """
 AFkagome = spinw;
@@ -50,8 +47,6 @@ if __name__ == "__main__":
     j1 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=0, max_distance=4.1, coupling_type=HeisenbergCoupling, j=1)
     j2 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=5, max_distance=5.2, coupling_type=HeisenbergCoupling, j=0.11)
     exchanges = j1 + j2
-
-    #debug_plot(s, exchanges, show=False)
 
     hamiltonian = Hamiltonian(s, exchanges)
 

--- a/examples/structures/kagome_antiferromagnet.py
+++ b/examples/structures/kagome_antiferromagnet.py
@@ -11,6 +11,7 @@ from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagati
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 from numpy import sqrt
+import sys
 
 from pyspinw.debug_plot import debug_plot
 
@@ -52,12 +53,11 @@ if __name__ == "__main__":
     j2 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=5, max_distance=5.2, coupling_type=HeisenbergCoupling, j=0.11)
     exchanges = j1 + j2
 
-    debug_plot(s, exchanges, show=False)
+    #debug_plot(s, exchanges, show=False)
 
     hamiltonian = Hamiltonian(s, exchanges)
 
     hamiltonian.print_summary()
-    hamiltonian.expand()
 
     path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
     hamiltonian.spaghetti_plot(path, use_rust=use_rust)

--- a/examples/structures/kagome_antiferromagnet.py
+++ b/examples/structures/kagome_antiferromagnet.py
@@ -39,10 +39,10 @@ if __name__ == "__main__":
 
     unit_cell = UnitCell(6, 6, 10, gamma=120)
 
-    x = LatticeSite(0.5, 0, 0, 1, 2, 0, S=1, name="X")
-    y = LatticeSite(0, 0.5, 0, -2, -1, 0, S=1, name="Y")
-    z = LatticeSite(0.5, 0.5, 0, 1, -1, 0, S=1, name="Z")
-    s = genmagstr([x, y, z], unit_cell, mode='tile', unit='lu')
+    x = LatticeSite(0.5, 0, 0, 1, 2, 0, name="X")
+    y = LatticeSite(0, 0.5, 0, -2, -1, 0, name="Y")
+    z = LatticeSite(0.5, 0.5, 0, 1, -1, 0, name="Z")
+    s = genmagstr([x, y, z], unit_cell, magnitude=[1,1,1], mode='tile', unit='lu')
 
     j1 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=0, max_distance=4.1, coupling_type=HeisenbergCoupling, j=1)
     j2 = couplings(sites=[x, y, z], unit_cell=unit_cell, min_distance=5, max_distance=5.2, coupling_type=HeisenbergCoupling, j=0.11)

--- a/examples/structures/kagome_ferromagnet.py
+++ b/examples/structures/kagome_ferromagnet.py
@@ -5,31 +5,48 @@ from multiprocessing.spawn import freeze_support
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
 from pyspinw.interface import spacegroup, couplings, filter
-from pyspinw.path import Path
+from pyspinw.path import Path, Path1D
 from pyspinw.site import LatticeSite
+from pyspinw.sample import Powder
 from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 
 from pyspinw.debug_plot import debug_plot
 
+"""
+FMkagome = spinw;
+FMkagome.genlattice('lat_const',[6 6 5],'angled',[90 90 120],'spgr','P -3')
+FMkagome.addatom('r', [1/2 0 0], 'S', 1, 'label','MCu1','color','r')
+FMkagome.gencoupling('maxDistance',4)
+FMkagome.addmatrix('label','J1','value',-1,'color','orange');
+FMkagome.addcoupling('mat','J1','bond',1);
+FMkagome.genmagstr('mode','helical','k',[0 0 0],'n',[0 1 0],'S',[0 1 0]')
+fmkSpec = FMkagome.spinwave({[-1/2 0 0] [0 0 0] [1/2 1/2 0] 100},'hermit',false);
+fmkSpec = sw_egrid(sw_neutron(fmkSpec), 'Evect',linspace(0,6.5,100),'component','Sperp');
+figure; sw_plotspec(fmkSpec,'mode',1,'colorbar',false,'axLim',[0 8])
+fmkPow = FMkagome.powspec(linspace(0,2.5,100),'Evect',linspace(0,7,250),'nRand',1000,'hermit',false);
+figure; sw_plotspec(fmkPow,'colorbar',true,'axLim',[0 0.05])
+"""
+
 if __name__ == "__main__":
+    """Reproduces Tutorial 5: https://spinw.org/tutorials/05tutorial"""
     freeze_support()
 
-    unit_cell = UnitCell(1,1,1, gamma=60)
+    unit_cell = UnitCell(6,6,5, gamma=120)
 
-    x = LatticeSite(0, 0, 0, 0, 0, 1, name="X")
-    y = LatticeSite(0.5, 0, 0, 0, 0, 1, name="Y")
-    z = LatticeSite(0, 0.5, 0, 0, 0, 1, name="Z")
+    x = LatticeSite(0.5, 0, 0, 0, 1, 0, name="X")
+    y = LatticeSite(0, 0.5, 0, 0, 1, 0, name="Y")
+    z = LatticeSite(0.5, 0.5, 0, 0, 1, 0, name="Z")
 
     sites = [x, y, z]
 
-    s = Structure(sites, unit_cell=unit_cell, supercell=TrivialSupercell(scaling=(3,3,1)))
+    s = Structure(sites, unit_cell=unit_cell, supercell=TrivialSupercell(scaling=(1,1,1)))
 
 
     exchanges = couplings(sites=[x, y, z],
                            unit_cell=unit_cell,
-                           max_distance=0.6,
+                           max_distance=4.,
                            coupling_type=HeisenbergCoupling,
                            j=-1)
 
@@ -39,9 +56,9 @@ if __name__ == "__main__":
 
     hamiltonian.print_summary()
 
-    path = Path([[-0.5,0,0], [0,0,0], [0,0.5,0.5]])
-    hamiltonian.energy_plot(path)
+    path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
+    hamiltonian.energy_plot(path, show=False)
 
-
-
-
+    sample = Powder(hamiltonian)
+    path1D = Path1D(0.1, 2.5, n_points=100)
+    sample.show_spectrum(path1D, n_energy_bins=250)

--- a/examples/structures/kagome_ferromagnet.py
+++ b/examples/structures/kagome_ferromagnet.py
@@ -4,7 +4,7 @@ from multiprocessing.spawn import freeze_support
 
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.interface import couplings
 from pyspinw.path import Path, Path1D
 from pyspinw.site import LatticeSite
 from pyspinw.sample import Powder
@@ -12,8 +12,6 @@ from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 import sys
-
-from pyspinw.debug_plot import debug_plot
 
 """
 FMkagome = spinw;
@@ -52,8 +50,6 @@ if __name__ == "__main__":
                            max_distance=4.,
                            coupling_type=HeisenbergCoupling,
                            j=-1)
-
-    debug_plot(s, exchanges, show=False)
 
     hamiltonian = Hamiltonian(s, exchanges)
 

--- a/examples/structures/kagome_ferromagnet.py
+++ b/examples/structures/kagome_ferromagnet.py
@@ -11,6 +11,7 @@ from pyspinw.sample import Powder
 from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
+import sys
 
 from pyspinw.debug_plot import debug_plot
 

--- a/examples/structures/kagome_ferromagnet.py
+++ b/examples/structures/kagome_ferromagnet.py
@@ -33,6 +33,8 @@ if __name__ == "__main__":
     """Reproduces Tutorial 5: https://spinw.org/tutorials/05tutorial"""
     freeze_support()
 
+    use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
+
     unit_cell = UnitCell(6,6,5, gamma=120)
 
     x = LatticeSite(0.5, 0, 0, 0, 1, 0, name="X")
@@ -57,7 +59,7 @@ if __name__ == "__main__":
     hamiltonian.print_summary()
 
     path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
-    hamiltonian.energy_plot(path, show=False)
+    hamiltonian.energy_plot(path, show=False, use_rust=use_rust)
 
     sample = Powder(hamiltonian)
     path1D = Path1D(0.1, 2.5, n_points=100)

--- a/examples/structures/kagome_supercell.py
+++ b/examples/structures/kagome_supercell.py
@@ -1,0 +1,60 @@
+""" Kagome 3x3 Antiferromagnet example """
+
+from multiprocessing.spawn import freeze_support
+
+from pyspinw.coupling import HeisenbergCoupling
+from pyspinw.hamiltonian import Hamiltonian
+from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.path import Path
+from pyspinw.site import LatticeSite
+from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector
+from pyspinw.symmetry.unitcell import UnitCell
+from pyspinw.structures import Structure
+from math import sqrt
+
+from pyspinw.debug_plot import debug_plot
+
+"""
+AF33kagome = spinw;
+AF33kagome.genlattice('lat_const',[6 6 40],'angled',[90 90 120],'spgr','P -3')
+AF33kagome.addatom('r',[1/2 0 0],'S', 1,'label','MCu1','color','r')
+AF33kagome.gencoupling('maxDistance',7)
+AF33kagome.addmatrix('label','J1','value',1.00,'color','g')
+AF33kagome.addcoupling('mat','J1','bond',1)
+S0 = [0 0 -1;
+      1 1 -1;
+      0 0 0];
+AF33kagome.genmagstr('mode','helical','k',[-1/3 -1/3 0],...
+    'n',[0 0 1],'unit','lu','S',S0,'nExt',0.1);
+kag33Spec = AF33kagome.spinwave({[-1/2 0 0] [0 0 0] [1/2 1/2 0] 250},'hermit',false);
+figure; sw_plotspec(kag33Spec)
+"""
+
+if __name__ == "__main__":
+    """Reproduces Tutorial 8: https://spinw.org/tutorials/08tutorial"""
+    freeze_support()
+
+    unit_cell = UnitCell(6, 6, 40, gamma=120)
+
+    x = LatticeSite(0.5, 0,   0, 0, 1, 0, name="X", unit="lu")
+    y = LatticeSite(0,   0.5, 0, 0, 1, 0, name="Y", unit="lu")
+    z = LatticeSite(0.5, 0.5, 0, -1, -1, 0, name="Z", unit="lu")
+
+    sites = [x, y, z]
+    k = CommensuratePropagationVector(-1./3., -1./3., 0)
+    s = Structure(sites, unit_cell=unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
+
+    exchanges = couplings(sites=[x, y, z],
+                          unit_cell=unit_cell,
+                          max_distance=3.1,
+                          coupling_type=HeisenbergCoupling,
+                          j=1)
+
+    debug_plot(s, exchanges, show=False)
+
+    hamiltonian = Hamiltonian(s, exchanges)
+
+    hamiltonian.print_summary()
+
+    path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
+    hamiltonian.plot(path, use_rust=False)

--- a/examples/structures/kagome_supercell.py
+++ b/examples/structures/kagome_supercell.py
@@ -7,7 +7,7 @@ from pyspinw.hamiltonian import Hamiltonian
 from pyspinw.interface import spacegroup, couplings, filter
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
-from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector
+from pyspinw.legacy.genmagstr import genmagstr
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 from math import sqrt
@@ -39,17 +39,10 @@ if __name__ == "__main__":
 
     unit_cell = UnitCell(6, 6, 40, gamma=120)
 
-    #x = LatticeSite(0.5, 0,   0, 0, 1, 0, name="X", unit="lu")
-    #y = LatticeSite(0,   0.5, 0, 0, 1, 0, name="Y", unit="lu")
-    #z = LatticeSite(0.5, 0.5, 0, -1, -1, 0, name="Z", unit="lu")
-    s3 = sqrt(3) / 2
-    x = LatticeSite(0.5, 0,   0, -0.5-s3*1j,  s3-0.5j, 0, name="X")
-    y = LatticeSite(0,   0.5, 0, -0.5-s3*1j,  s3-0.5j, 0, name="Y")
-    z = LatticeSite(0.5, 0.5, 0, -0.5+s3*1j, -s3-0.5j, 0, name="Z")
-
-    sites = [x, y, z]
-    k = CommensuratePropagationVector(-1./3., -1./3., 0)
-    s = Structure(sites, unit_cell=unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
+    x = LatticeSite(0.5, 0,   0, 0, 1, 0, S=1, name="X")
+    y = LatticeSite(0,   0.5, 0, 0, 1, 0, S=1, name="Y")
+    z = LatticeSite(0.5, 0.5, 0, -1, -1, 0, S=1, name="Z")
+    s = genmagstr([x, y, z], unit_cell, mode='helical', k=[-1./3, -1./3, 0], n=[0, 0, 1], unit='lu')
 
     exchanges = couplings(sites=[x, y, z],
                           unit_cell=unit_cell,

--- a/examples/structures/kagome_supercell.py
+++ b/examples/structures/kagome_supercell.py
@@ -4,16 +4,13 @@ from multiprocessing.spawn import freeze_support
 
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.interface import couplings
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
 from pyspinw.legacy.genmagstr import genmagstr
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
-from math import sqrt
 import sys
-
-from pyspinw.debug_plot import debug_plot
 
 """
 AF33kagome = spinw;
@@ -28,7 +25,11 @@ S0 = [0 0 -1;
 AF33kagome.genmagstr('mode','helical','k',[-1/3 -1/3 0],...
     'n',[0 0 1],'unit','lu','S',S0,'nExt',0.1);
 kag33Spec = AF33kagome.spinwave({[-1/2 0 0] [0 0 0] [1/2 1/2 0] 250},'hermit',false);
-figure; sw_plotspec(kag33Spec)
+figure; subplot(211)
+sw_plotspec(kag33Spec,'mode',1,'colorbar',false,'colormap',[0 0 0],'dashed',true,'axLim',[0 3])
+kag33Spec = sw_egrid(sw_neutron(kag33Spec),'Evect',linspace(0,6.5,500),'component','Sperp');
+kag33Spec = sw_omegasum(kag33Spec,'zeroint',1e-6);
+subplot(212); sw_plotspec(kag33Spec,'mode',2,'log',false,'axLim',[0 3])
 """
 
 if __name__ == "__main__":
@@ -50,8 +51,6 @@ if __name__ == "__main__":
                           coupling_type=HeisenbergCoupling,
                           j=1)
 
-    #debug_plot(s, exchanges, show=False)
-
     hamiltonian = Hamiltonian(s, exchanges)
 
     hamiltonian.print_summary()
@@ -62,5 +61,6 @@ if __name__ == "__main__":
     path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
     import matplotlib.pyplot as plt
     fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust)
+    fig.axes[0].set_ylim(0, 3)
     fig.axes[1].set_ylim(0, 1)
     plt.show()

--- a/examples/structures/kagome_supercell.py
+++ b/examples/structures/kagome_supercell.py
@@ -11,6 +11,7 @@ from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagati
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 from math import sqrt
+import sys
 
 from pyspinw.debug_plot import debug_plot
 
@@ -34,11 +35,17 @@ if __name__ == "__main__":
     """Reproduces Tutorial 8: https://spinw.org/tutorials/08tutorial"""
     freeze_support()
 
+    use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
+
     unit_cell = UnitCell(6, 6, 40, gamma=120)
 
-    x = LatticeSite(0.5, 0,   0, 0, 1, 0, name="X", unit="lu")
-    y = LatticeSite(0,   0.5, 0, 0, 1, 0, name="Y", unit="lu")
-    z = LatticeSite(0.5, 0.5, 0, -1, -1, 0, name="Z", unit="lu")
+    #x = LatticeSite(0.5, 0,   0, 0, 1, 0, name="X", unit="lu")
+    #y = LatticeSite(0,   0.5, 0, 0, 1, 0, name="Y", unit="lu")
+    #z = LatticeSite(0.5, 0.5, 0, -1, -1, 0, name="Z", unit="lu")
+    s3 = sqrt(3) / 2
+    x = LatticeSite(0.5, 0,   0, -0.5-s3*1j,  s3-0.5j, 0, name="X")
+    y = LatticeSite(0,   0.5, 0, -0.5-s3*1j,  s3-0.5j, 0, name="Y")
+    z = LatticeSite(0.5, 0.5, 0, -0.5+s3*1j, -s3-0.5j, 0, name="Z")
 
     sites = [x, y, z]
     k = CommensuratePropagationVector(-1./3., -1./3., 0)
@@ -50,11 +57,17 @@ if __name__ == "__main__":
                           coupling_type=HeisenbergCoupling,
                           j=1)
 
-    debug_plot(s, exchanges, show=False)
+    #debug_plot(s, exchanges, show=False)
 
     hamiltonian = Hamiltonian(s, exchanges)
 
     hamiltonian.print_summary()
 
+    #from pyspinw.gui.viewer import show_hamiltonian
+    #show_hamiltonian(hamiltonian)
+
     path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
-    hamiltonian.spaghetti_plot(path, use_rust=False)
+    import matplotlib.pyplot as plt
+    fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust)
+    fig.axes[1].set_ylim(0, 1)
+    plt.show()

--- a/examples/structures/kagome_supercell.py
+++ b/examples/structures/kagome_supercell.py
@@ -57,4 +57,4 @@ if __name__ == "__main__":
     hamiltonian.print_summary()
 
     path = Path([[-0.5,0,0], [0,0,0], [0.5,0.5,0]])
-    hamiltonian.plot(path, use_rust=False)
+    hamiltonian.spaghetti_plot(path, use_rust=False)

--- a/examples/structures/kagome_supercell.py
+++ b/examples/structures/kagome_supercell.py
@@ -40,10 +40,10 @@ if __name__ == "__main__":
 
     unit_cell = UnitCell(6, 6, 40, gamma=120)
 
-    x = LatticeSite(0.5, 0,   0, 0, 1, 0, S=1, name="X")
-    y = LatticeSite(0,   0.5, 0, 0, 1, 0, S=1, name="Y")
-    z = LatticeSite(0.5, 0.5, 0, -1, -1, 0, S=1, name="Z")
-    s = genmagstr([x, y, z], unit_cell, mode='helical', k=[-1./3, -1./3, 0], n=[0, 0, 1], unit='lu')
+    x = LatticeSite(0.5, 0,   0, 0, 1, 0, name="X")
+    y = LatticeSite(0,   0.5, 0, 0, 1, 0, name="Y")
+    z = LatticeSite(0.5, 0.5, 0, -1, -1, 0, name="Z")
+    s = genmagstr([x, y, z], unit_cell, magnitude=[1,1,1], mode='helical', k=[-1./3, -1./3, 0], n=[0, 0, 1], unit='lu')
 
     exchanges = couplings(sites=[x, y, z],
                           unit_cell=unit_cell,

--- a/examples/structures/powder_spectrum.py
+++ b/examples/structures/powder_spectrum.py
@@ -4,11 +4,10 @@ from multiprocessing.spawn import freeze_support
 
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.interface import couplings, filter
 from pyspinw.path import Path, Path1D
 from pyspinw.sample import Powder
 from pyspinw.site import LatticeSite
-from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 

--- a/examples/structures/powder_spectrum.py
+++ b/examples/structures/powder_spectrum.py
@@ -4,10 +4,11 @@ from multiprocessing.spawn import freeze_support
 
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import couplings, filter
+from pyspinw.interface import spacegroup, couplings, filter
 from pyspinw.path import Path, Path1D
 from pyspinw.sample import Powder
 from pyspinw.site import LatticeSite
+from pyspinw.symmetry.supercell import TrivialSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 
@@ -37,5 +38,5 @@ if __name__ == "__main__":
 
     sample = Powder(hamiltonian)
 
-    path1D = Path1D(0.1, 0.9, n_points=201)
-    sample.show_spectrum(path1D, n_energy_bins=20)
+    path1D = Path1D()
+    sample.show_spectrum(path1D, n_energy_bins=100, n_samples=500)

--- a/examples/structures/square_antiferromagnet.py
+++ b/examples/structures/square_antiferromagnet.py
@@ -1,0 +1,55 @@
+""" Square-lattice Antiferromagnet example """
+
+from multiprocessing.spawn import freeze_support
+
+from pyspinw.coupling import HeisenbergCoupling
+from pyspinw.hamiltonian import Hamiltonian
+from pyspinw.interface import couplings
+from pyspinw.path import Path
+from pyspinw.site import LatticeSite
+from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector
+from pyspinw.symmetry.unitcell import UnitCell
+from pyspinw.structures import Structure
+from pyspinw.legacy.genmagstr import genmagstr
+from math import sqrt
+import sys
+
+"""
+[J, Jp, Jpp, Jc] = deal(138.3, 2, 2, 38);
+lacuo = sw_model('squareAF',[J-Jc/2 Jp-Jc/4 Jpp]/2,0);
+lacuo.unit_cell.S = 1/2;
+lacuoSpec = lacuo.spinwave({[3/4 1/4 0] [1/2 1/2 0] [1/2 0 0] [3/4 1/4 0] [1 0 0] [1/2 0 0] 100},'hermit',false);
+lacuoSpec = sw_egrid(sw_neutron(lacuoSpec),'component','Sperp');
+figure; subplot(2,1,1)
+sw_plotspec(lacuoSpec,'mode','disp','axLim',[0 350],'dE',35,'dashed',true)
+subplot(2,1,2)
+lacuoSpec = sw_omegasum(lacuoSpec,'zeroint',1e-5,'tol',1e-3);
+sw_plotspec(lacuoSpec,'mode',2,'axLim',[0 20],'dashed',true,'colormap',[0 0 0])
+"""
+
+if __name__ == "__main__":
+    """Reproduces Tutorial 11: https://spinw.org/tutorials/11tutorial"""
+    freeze_support()
+
+    use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
+
+    unit_cell = UnitCell(3, 3, 9)
+
+    sites = [LatticeSite(0, 0, 0, 1, 0, 0, name="X")]
+    k = CommensuratePropagationVector(0.5, 0.5, 0)
+    s = Structure(sites, unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
+
+    j1 = couplings(sites, unit_cell, min_distance=0, max_distance=3.1, coupling_type=HeisenbergCoupling, j=59.65)
+    j2 = couplings(sites, unit_cell, min_distance=4, max_distance=4.3, coupling_type=HeisenbergCoupling, j=-3.75)
+    j3 = couplings(sites, unit_cell, min_distance=5, max_distance=6.1, coupling_type=HeisenbergCoupling, j=1)
+    exchanges = j1 + j2 + j3
+
+    hamiltonian = Hamiltonian(s, exchanges)
+    hamiltonian.print_summary()
+
+    path = Path([[3/4, 1/4, 0], [1/2, 1/2, 0], [1/2, 0, 0], [3/4, 1/4, 0], [1, 0, 0], [1/2, 0, 0]], n_points_per_segment=51)
+    import matplotlib.pyplot as plt
+    fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust)
+    fig.axes[0].set_ylim(0, 600)
+    fig.axes[1].set_ylim(0, 20)
+    plt.show()

--- a/examples/structures/triangular_antiferro.py
+++ b/examples/structures/triangular_antiferro.py
@@ -56,5 +56,8 @@ if __name__ == "__main__":
 
     hamiltonian.print_summary()
 
-    path = Path([[0,0,0], [1,1,0]])
-    hamiltonian.plot(path)
+    path = Path([[0,0,0], [1,1,0]], n_points_per_segment=401)
+    import matplotlib.pyplot as plt
+    fig = hamiltonian.spaghetti_plot(path, show=False)
+    fig.axes[1].set_ylim(0, 5)
+    plt.show()

--- a/examples/structures/triangular_antiferro.py
+++ b/examples/structures/triangular_antiferro.py
@@ -12,6 +12,7 @@ from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagati
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 from math import sqrt
+import sys
 
 from pyspinw.debug_plot import debug_plot
 

--- a/examples/structures/triangular_antiferro.py
+++ b/examples/structures/triangular_antiferro.py
@@ -37,6 +37,8 @@ if __name__ == "__main__":
     """Reproduces Tutorial 12: https://spinw.org/tutorials/12tutorial"""
     freeze_support()
 
+    use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
+
     unit_cell = UnitCell(3, 3, 4, gamma=120)
 
     sites = [LatticeSite(0, 0, 0, -1j, 1, 0, name="X")]
@@ -58,6 +60,6 @@ if __name__ == "__main__":
 
     path = Path([[0,0,0], [1,1,0]], n_points_per_segment=401)
     import matplotlib.pyplot as plt
-    fig = hamiltonian.spaghetti_plot(path, show=False)
+    fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust)
     fig.axes[1].set_ylim(0, 5)
     plt.show()

--- a/examples/structures/triangular_antiferro.py
+++ b/examples/structures/triangular_antiferro.py
@@ -8,9 +8,9 @@ from pyspinw.interface import spacegroup, couplings, filter
 from pyspinw.interface import spacegroup, couplings, filter, axis_anisotropies
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
-from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
+from pyspinw.legacy.genmagstr import genmagstr
 from math import sqrt
 import sys
 
@@ -42,9 +42,8 @@ if __name__ == "__main__":
 
     unit_cell = UnitCell(3, 3, 4, gamma=120)
 
-    sites = [LatticeSite(0, 0, 0, -1j, 1, 0, name="X")]
-    k = CommensuratePropagationVector(1./3., 1./3., 0)
-    s = Structure(sites, unit_cell=unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
+    sites = [LatticeSite(0, 0, 0, 0, 1, 0, S=3./2, name="X")]
+    s = genmagstr(sites, unit_cell, mode='helical', k=[1./3, 1./3, 0], n=[0, 0, 1])
 
     exchanges = couplings(sites=sites,
                           unit_cell=unit_cell,

--- a/examples/structures/triangular_antiferro.py
+++ b/examples/structures/triangular_antiferro.py
@@ -1,0 +1,60 @@
+""" Triangular Antiferromagnet example """
+
+from multiprocessing.spawn import freeze_support
+
+from pyspinw.coupling import HeisenbergCoupling
+from pyspinw.hamiltonian import Hamiltonian
+from pyspinw.interface import spacegroup, couplings, filter
+from pyspinw.interface import spacegroup, couplings, filter, axis_anisotropies
+from pyspinw.path import Path
+from pyspinw.site import LatticeSite
+from pyspinw.symmetry.supercell import SummationSupercell, CommensuratePropagationVector
+from pyspinw.symmetry.unitcell import UnitCell
+from pyspinw.structures import Structure
+from math import sqrt
+
+from pyspinw.debug_plot import debug_plot
+
+"""
+tri = spinw;
+tri.genlattice('lat_const',[3 3 4],'angled',[90 90 120])
+tri.addatom('r',[0 0 0],'S',3/2,'label','MCr3','color','orange')
+tri.gencoupling()
+tri.addmatrix('value',1,'label','J','color','SteelBlue')
+tri.addcoupling('mat','J','bond',1)
+tri.addmatrix('value',diag([0 0 0.2]),'label','D','color','r')
+tri.addaniso('D')
+tri.genmagstr('mode','helical','S',[0; 1; 0],'k',[1/3 1/3 0],'n', [0 0 1],'nExt',0.1);
+triSpec = sw_neutron(tri.spinwave({[0 0 0] [1 1 0] 500}));
+figure; subplot(211)
+sw_plotspec(triSpec,'mode','disp','axLim',[0 7],'colormap',[0 0 0],'colorbar',false)
+triSpec = sw_egrid(triSpec,'Evect',linspace(0,6.5,500),'component','Sperp');
+triSpec = sw_omegasum(triSpec,'zeroint',1e-6);
+subplot(212); sw_plotspec(triSpec,'mode',2,'log',false,'axLim',[0 3])
+"""
+
+if __name__ == "__main__":
+    """Reproduces Tutorial 12: https://spinw.org/tutorials/12tutorial"""
+    freeze_support()
+
+    unit_cell = UnitCell(3, 3, 4, gamma=120)
+
+    sites = [LatticeSite(0, 0, 0, -1j, 1, 0, name="X")]
+    k = CommensuratePropagationVector(1./3., 1./3., 0)
+    s = Structure(sites, unit_cell=unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
+
+    exchanges = couplings(sites=sites,
+                          unit_cell=unit_cell,
+                          max_distance=3.1,
+                          coupling_type=HeisenbergCoupling,
+                          j=1)
+
+    debug_plot(s, exchanges, show=False)
+
+    anisotropies = axis_anisotropies(sites, 0.2)
+    hamiltonian = Hamiltonian(s, exchanges, anisotropies)
+
+    hamiltonian.print_summary()
+
+    path = Path([[0,0,0], [1,1,0]])
+    hamiltonian.plot(path)

--- a/examples/structures/triangular_antiferro.py
+++ b/examples/structures/triangular_antiferro.py
@@ -4,17 +4,13 @@ from multiprocessing.spawn import freeze_support
 
 from pyspinw.coupling import HeisenbergCoupling
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.interface import spacegroup, couplings, filter
-from pyspinw.interface import spacegroup, couplings, filter, axis_anisotropies
+from pyspinw.interface import couplings, axis_anisotropies
 from pyspinw.path import Path
 from pyspinw.site import LatticeSite
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
 from pyspinw.legacy.genmagstr import genmagstr
-from math import sqrt
 import sys
-
-from pyspinw.debug_plot import debug_plot
 
 """
 tri = spinw;
@@ -51,8 +47,6 @@ if __name__ == "__main__":
                           coupling_type=HeisenbergCoupling,
                           j=1)
 
-    debug_plot(s, exchanges, show=False)
-
     anisotropies = axis_anisotropies(sites, 0.2)
     hamiltonian = Hamiltonian(s, exchanges, anisotropies)
 
@@ -61,5 +55,6 @@ if __name__ == "__main__":
     path = Path([[0,0,0], [1,1,0]], n_points_per_segment=401)
     import matplotlib.pyplot as plt
     fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust)
+    fig.axes[0].set_ylim(0, 10)
     fig.axes[1].set_ylim(0, 5)
     plt.show()

--- a/examples/structures/triangular_antiferro.py
+++ b/examples/structures/triangular_antiferro.py
@@ -38,8 +38,8 @@ if __name__ == "__main__":
 
     unit_cell = UnitCell(3, 3, 4, gamma=120)
 
-    sites = [LatticeSite(0, 0, 0, 0, 1, 0, S=3./2, name="X")]
-    s = genmagstr(sites, unit_cell, mode='helical', k=[1./3, 1./3, 0], n=[0, 0, 1])
+    sites = [LatticeSite(0, 0, 0, 0, 1, 0, name="X")]
+    s = genmagstr(sites, unit_cell, magnitude=[3./2],mode='helical', k=[1./3, 1./3, 0], n=[0, 0, 1])
 
     exchanges = couplings(sites=sites,
                           unit_cell=unit_cell,

--- a/pyspinw/basis.py
+++ b/pyspinw/basis.py
@@ -34,13 +34,13 @@ def find_aligned_basis(vectors: np.ndarray, rcond: float | None = None) -> tuple
     # Second basis, cross with x-axis vector, unless its pointing that way already, then we choose y-axis explicitly
     #
 
-    x_aligned = np.abs(e_1[:, 0] - 1) < rcond
+    x_aligned = (np.abs(e_1[:, 1]) + np.abs(e_1[:, 2])) < rcond
 
     x_vectors = np.zeros_like(vectors)
-    x_vectors[:, 0] = 1.0
+    x_vectors[:, 0] = -1.0
 
     e_2 = np.cross(e_1, x_vectors)
-    e_2[x_aligned, :] = np.array([[0.0, 1.0, 0.0]])
+    e_2[x_aligned, :] = np.array([[0.0, 0.0, 1.0]])
     e_2 /= np.sqrt(np.sum(e_2**2, axis=1)).reshape(-1, 1) # Normalise this one
 
     #

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -325,7 +325,10 @@ def _calc_chunk_spinwave(
             kk = sqrt_hamiltonian.conj().T
             for jj in range(kk.shape[0]):
                 kk[jj, jj] = max(kk[jj, jj], 1e-7)
-            T = solve(kk, eigvecs @ np.diag(sqrt_E))
+            if np.linalg.cond(kk) > 1e16:
+                T = np.zeros((2 * n_sites, 2 * n_sites)) * np.nan
+            else:
+                T = solve(kk, eigvecs @ np.diag(sqrt_E))
 
         # Apply transformation matrix to S'^alpha,beta block matrices T*[VW;YZ]T
         # and then we just take the diagonal elements as that's all we need for

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -29,6 +29,10 @@ class Coupling:
     matrix: np.ndarray
     inter_site_vector: np.ndarray
 
+    def __eq__(self, other):
+        return self.index1 == other.index1 and self.index2 == other.index2 \
+                and np.allclose(self.matrix, other.matrix) \
+                and np.allclose(self.inter_site_vector, other.inter_site_vector)
 
 @dataclass
 class MagneticField:

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -320,11 +320,12 @@ def _calc_chunk_spinwave(
         try:
             # rather than inverting K explicitly, calculate T by solving KT = U sqrt(E)
             T = solve(sqrt_hamiltonian.conj().T, eigvecs @ np.diag(sqrt_E))
-        except np.linalg.LinAlgError:
+            assert not np.isnan(T).any(), "singular matrix"
+        except (AssertionError, np.linalg.LinAlgError):
             # if K is singular, then add a small amount to the diagonal.
             kk = sqrt_hamiltonian.conj().T
             for jj in range(kk.shape[0]):
-                kk[jj, jj] = max(kk[jj, jj], 1e-7)
+                kk[jj, jj] += 1e-7
             if np.linalg.cond(kk) > 1e16:
                 T = np.zeros((2 * n_sites, 2 * n_sites)) * np.nan
             else:

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -71,8 +71,7 @@ def _calc_q_independent(
     C = np.zeros((n_sites, n_sites), dtype=complex)
     for coupling in couplings:
         i, j = (coupling.index1, coupling.index2)
-        C[j, j] += spin_coefficients[j, j] * eta[i, :].T @ coupling.matrix @ eta[j, :]
-    C *= 2
+        C[j, j] += magnitudes[j] * eta[i, :].T @ coupling.matrix @ eta[j, :]
 
     # calculate the Zeeman term for the A matrix (A^z in Toth & Lake)
     if field is not None:

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -71,7 +71,8 @@ def _calc_q_independent(
     C = np.zeros((n_sites, n_sites), dtype=complex)
     for coupling in couplings:
         i, j = (coupling.index1, coupling.index2)
-        C[j, j] += magnitudes[j] * eta[i, :].T @ coupling.matrix @ eta[j, :]
+        C[j, j] += spin_coefficients[j, j] * eta[i, :].T @ coupling.matrix @ eta[j, :]
+    C *= 2
 
     # calculate the Zeeman term for the A matrix (A^z in Toth & Lake)
     if field is not None:

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -340,7 +340,7 @@ def _calc_chunk_spinwave(
         # S'^alpha,beta(k, omega) at each eigenvalue
         # this is a 3x3x2N array indexed by [alpha, beta, omega]
         sab = np.array([[np.diag(T.conj().T @ sab_blocks[alpha, beta] @ T) for alpha in range(3)] for beta in range(3)])
-        sab /= n_sites
+        sab /= 2 * n_sites
 
         # take perpendicular component s_perp of sab
         if (q_mag := np.linalg.norm(q)) == 0:

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -76,6 +76,8 @@ def _calc_q_independent(
     for coupling in couplings:
         i, j = (coupling.index1, coupling.index2)
         C[j, j] += magnitudes[j] * eta[i, :].T @ coupling.matrix @ eta[j, :]
+    # Adds a small delta to diagonal to ensure we don't have an exact degeneracies
+    C -= np.diag(np.array(range(C.shape[0]))*1e-12)
 
     # calculate the Zeeman term for the A matrix (A^z in Toth & Lake)
     if field is not None:
@@ -118,7 +120,6 @@ def _calc_sqrt_hamiltonian(
         A += Az
 
     hamiltonian_matrix = np.block([[A - C, B], [B.conj().T, A.conj().T - C]])
-    hamiltonian_matrix += np.diag(np.array(range(hamiltonian_matrix.shape[0]))*1e-12)
 
     # We need to enforce the bosonic commutation properties, we do this
     # by finding the 'square root' of the matrix (i.e. finding K such that KK^dagger = H)

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -340,7 +340,7 @@ def _calc_chunk_spinwave(
         # S'^alpha,beta(k, omega) at each eigenvalue
         # this is a 3x3x2N array indexed by [alpha, beta, omega]
         sab = np.array([[np.diag(T.conj().T @ sab_blocks[alpha, beta] @ T) for alpha in range(3)] for beta in range(3)])
-        sab /= 2 * n_sites
+        sab /= n_sites
 
         # take perpendicular component s_perp of sab
         if (q_mag := np.linalg.norm(q)) == 0:

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -181,7 +181,7 @@ class Hamiltonian(SPWSerialisable):
         lu2xyz /= np.sqrt(np.sum(lu2xyz**2, axis=1)).reshape(-1, 1)
         for index, site in enumerate(expanded._structure.sites):
             # TODO: Sort out moments for supercells
-            moments.append(site.xyz_moment(self.structure.unit_cell._xyz))
+            moments.append(site.xyz_moment(lu2xyz))
 
             positions.append(site.ijk)
 

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -275,35 +275,50 @@ class Hamiltonian(SPWSerialisable):
             return zip(energies, intensities)
         return energies
 
+    def plot(self,
+             path: Path,
+             field: ArrayLike | None = None,
+             show: bool=True,
+             new_figure: bool=True,
+             use_rust: bool=True,
+             scale: str='linear'):
+        """ Create a spaghetti diagram with energy top and intensity bottom """
+        if new_figure:
+            fg, axs = plt.subplots(2, 1)
+        else:
+            fg = plt.gcf()
+            axs = fg.get_axes()
+            for ii in range(len(axs), 2):
+                axs.append(fg.add_subplot(2,1,ii+1))
+
+        x_values = path.x_values()
+
+        for series in self.sorted_positive_energies(path, field=field, use_rust=use_rust, return_intensities=True):
+            axs[0].plot(x_values, series[0], 'k')
+            axs[1].plot(x_values, series[1])
+        if 'log' in scale:
+            axs[1].set_yscale('log')
+
+        path.format_plot(axs[0])
+        path.format_plot(axs[1])
+
+        if show:
+            plt.show()
+
     def energy_plot(self,
                     path: Path,
                     field: ArrayLike | None = None,
                     show: bool=True,
                     new_figure: bool=True,
-                    use_rust: bool=True,
-                    show_intensities=False):
+                    use_rust: bool=True):
         """ Create a spaghetti diagram """
-        if new_figure and show_intensities:
-            fg, axs = plt.subplots(2, 1)
-        elif show_intensities:
-            fg = plt.gcf()
-            axs = fg.get_axes()
-            for ii in range(len(axs), 2):
-                axs.append(fg.add_subplot(2,1,ii+1))
-        elif new_figure:
+        if new_figure:
             plt.figure("Energy")
 
         x_values = path.x_values()
 
-        if show_intensities:
-            for series in self.sorted_positive_energies(path, field=field, use_rust=use_rust, return_intensities=True):
-                axs[0].plot(x_values, series[0], 'k')
-                axs[1].plot(x_values, series[1])
-            if axs[1].get_ylim()[1] > 1e3:
-                axs[1].set_ylim([0, 10])
-        else:
-            for series in self.sorted_positive_energies(path, field=field, use_rust=use_rust):
-                plt.plot(x_values, series, 'k')
+        for series in self.sorted_positive_energies(path, field=field, use_rust=use_rust):
+            plt.plot(x_values, series, 'k')
 
         path.format_plot(plt)
 

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -298,6 +298,8 @@ class Hamiltonian(SPWSerialisable):
             for series in self.sorted_positive_energies(path, field=field, use_rust=use_rust, return_intensities=True):
                 axs[0].plot(x_values, series[0], 'k')
                 axs[1].plot(x_values, series[1])
+            if axs[1].get_ylim()[1] > 1e3:
+                axs[1].set_ylim([0, 10])
         else:
             for series in self.sorted_positive_energies(path, field=field, use_rust=use_rust):
                 plt.plot(x_values, series, 'k')

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -192,11 +192,9 @@ class Hamiltonian(SPWSerialisable):
         moments = []
         positions = []
         unique_id_to_index: dict[int, int] = {}
-        lu2xyz = self.structure.unit_cell._xyz
-        lu2xyz /= np.sqrt(np.sum(lu2xyz**2, axis=1)).reshape(-1, 1)
         for index, site in enumerate(expanded._structure.sites):
             # TODO: Sort out moments for supercells
-            moments.append(site.xyz_moment(lu2xyz))
+            moments.append(site.base_moment)
 
             positions.append(site.ijk)
 

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -177,8 +177,8 @@ class Hamiltonian(SPWSerialisable):
         moments = []
         positions = []
         unique_id_to_index: dict[int, int] = {}
-        lu2xyz = self.structure.unit_cell._xyz 
-        lu2xyz /= np.sqrt(np.sum(lu2xyz**2, axis=1)).reshape(-1, 1) 
+        lu2xyz = self.structure.unit_cell._xyz
+        lu2xyz /= np.sqrt(np.sum(lu2xyz**2, axis=1)).reshape(-1, 1)
         for index, site in enumerate(expanded._structure.sites):
             # TODO: Sort out moments for supercells
             moments.append(site.xyz_moment(self.structure.unit_cell._xyz))

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -263,6 +263,7 @@ class Hamiltonian(SPWSerialisable):
                         q_vectors=q_vectors * self.structure.supercell.scaling,
                         couplings=couplings,
                         positions=positions,
+                        rlu_to_cart=np.linalg.inv(self.structure.unit_cell._xyz).T * 2 * np.pi,
                         field=magnetic_field)
 
         return result[0], result[1]

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -207,10 +207,11 @@ class Hamiltonian(SPWSerialisable):
         for input_coupling in expanded.couplings:
             # Normal coupling
 
+            # Factor of 1/2 is due to double counting correction
             coupling = coupling_class(
                 unique_id_to_index[input_coupling.site_1._unique_id],
                 unique_id_to_index[input_coupling.site_2._unique_id],
-                np.array(input_coupling.coupling_matrix, **rust_kw),
+                np.array(input_coupling.coupling_matrix, **rust_kw) / 2.,
                 input_coupling.cell_offset.vector.astype('double')
             )
 
@@ -221,7 +222,7 @@ class Hamiltonian(SPWSerialisable):
             coupling = coupling_class(
                 unique_id_to_index[input_coupling.site_2._unique_id],
                 unique_id_to_index[input_coupling.site_1._unique_id],
-                np.array(input_coupling.coupling_matrix.T, **rust_kw),
+                np.array(input_coupling.coupling_matrix.T, **rust_kw) / 2.,
                 -input_coupling.cell_offset.vector.astype('double')
             )
 

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -226,7 +226,7 @@ class Hamiltonian(SPWSerialisable):
             coupling = coupling_class(
                 unique_id_to_index[input_coupling.site_1._unique_id],
                 unique_id_to_index[input_coupling.site_2._unique_id],
-                np.array(input_coupling.coupling_matrix, **rust_kw) / 2.,
+                np.array(input_coupling.coupling_matrix, **rust_kw),
                 input_coupling.cell_offset.vector.astype('double')
             )
 
@@ -237,11 +237,15 @@ class Hamiltonian(SPWSerialisable):
             coupling = coupling_class(
                 unique_id_to_index[input_coupling.site_2._unique_id],
                 unique_id_to_index[input_coupling.site_1._unique_id],
-                np.array(input_coupling.coupling_matrix.T, **rust_kw) / 2.,
+                np.array(input_coupling.coupling_matrix.T, **rust_kw),
                 -input_coupling.cell_offset.vector.astype('double')
             )
 
             couplings.append(coupling)
+
+        # Remove duplicate couplings
+        couplings = [c1 for ic, c1 in enumerate(couplings)
+                     if all([c1 != c2 for c2 in couplings[ic+1:]])]
 
         # Add in anisotropies as spinwave_calculation couplings
         for input_anisotropy in expanded.anisotropies:

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -181,8 +181,7 @@ class Hamiltonian(SPWSerialisable):
             # TODO: Sort out moments for supercells
             moments.append(site.base_moment)
 
-            positions.append(
-                expanded.structure.unit_cell.fractional_to_cartesian(site.ijk))
+            positions.append(site.ijk)
 
             unique_id_to_index[site._unique_id] = index
 
@@ -212,7 +211,7 @@ class Hamiltonian(SPWSerialisable):
                 unique_id_to_index[input_coupling.site_1._unique_id],
                 unique_id_to_index[input_coupling.site_2._unique_id],
                 np.array(input_coupling.coupling_matrix, **rust_kw),
-                input_coupling.vector(expanded.structure.unit_cell)
+                input_coupling.cell_offset.vector
             )
 
             couplings.append(coupling)
@@ -223,7 +222,7 @@ class Hamiltonian(SPWSerialisable):
                 unique_id_to_index[input_coupling.site_2._unique_id],
                 unique_id_to_index[input_coupling.site_1._unique_id],
                 np.array(input_coupling.coupling_matrix.T, **rust_kw),
-                -input_coupling.vector(expanded.structure.unit_cell)
+                -input_coupling.cell_offset.vector
             )
 
             couplings.append(coupling)
@@ -243,7 +242,7 @@ class Hamiltonian(SPWSerialisable):
         result = spinwave_calculation(
                         rotations=rotations,
                         magnitudes=magnitudes,
-                        q_vectors=q_vectors,
+                        q_vectors=q_vectors * self.structure.supercell.scaling,
                         couplings=couplings,
                         positions=positions,
                         field=magnetic_field)

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -263,16 +263,16 @@ class Hamiltonian(SPWSerialisable):
         energy = np.array(energy)
 
         # Sort the energies
-        idx_en = np.argsort(energy.real, axis=1)
+        energy_index = np.argsort(energy.real, axis=1)
 
         # return the top half (positive)
         n_energies = energy.shape[1]
 
-        energy = np.take_along_axis(energy, idx_en, axis=1)
+        energy = np.take_along_axis(energy, energy_index, axis=1)
         energies = [energy[:, n_energies - i - 1] for i in range(n_energies//2)]
 
         if return_intensities:
-            intensities = np.take_along_axis(np.array(intensities), idx_en, axis=1)
+            intensities = np.take_along_axis(np.array(intensities), energy_index, axis=1)
             intensities = [intensities[:, n_energies - i - 1] for i in range(n_energies//2)]
             return zip(energies, intensities)
         return energies
@@ -286,12 +286,12 @@ class Hamiltonian(SPWSerialisable):
              scale: str='linear'):
         """ Create a spaghetti diagram with energy top and intensity bottom """
         if new_figure:
-            fg, axs = plt.subplots(2, 1)
+            fig, axs = plt.subplots(2, 1)
         else:
-            fg = plt.gcf()
-            axs = fg.get_axes()
+            fig = plt.gcf()
+            axs = fig.get_axes()
             for ii in range(len(axs), 2):
-                axs.append(fg.add_subplot(2,1,ii+1))
+                axs.append(fig.add_subplot(2,1,ii+1))
 
         x_values = path.x_values()
 

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -177,9 +177,11 @@ class Hamiltonian(SPWSerialisable):
         moments = []
         positions = []
         unique_id_to_index: dict[int, int] = {}
+        lu2xyz = self.structure.unit_cell._xyz 
+        lu2xyz /= np.sqrt(np.sum(lu2xyz**2, axis=1)).reshape(-1, 1) 
         for index, site in enumerate(expanded._structure.sites):
             # TODO: Sort out moments for supercells
-            moments.append(site.base_moment)
+            moments.append(site.xyz_moment(self.structure.unit_cell._xyz))
 
             positions.append(site.ijk)
 

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -253,7 +253,7 @@ class Hamiltonian(SPWSerialisable):
             anisotropy = coupling_class(
                 unique_id_to_index[input_anisotropy.site._unique_id],
                 unique_id_to_index[input_anisotropy.site._unique_id],
-                np.array(input_anisotropy.anisotropy_matrix.T, **rust_kw),
+                np.array(input_anisotropy.anisotropy_matrix.T, **rust_kw) * 2.,
                 inter_site_vector=np.array([0,0,0], dtype=float)
             )
 

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -268,7 +268,12 @@ class Hamiltonian(SPWSerialisable):
                         rlu_to_cart=np.linalg.inv(self.structure.unit_cell._xyz).T * 2 * np.pi,
                         field=magnetic_field)
 
-        return result[0], result[1]
+        # Applies a rescaling to agree with Matlab code for Sab
+        # Toth & Lake eq (46) gives a 1/(2Natom) prefactor but the Matlab code uses 1/(2*Ncell)
+        scale_factor = rotations.shape[0] / np.prod(self.structure.supercell.scaling)
+        intensity = [res * scale_factor for res in result[1]]
+
+        return result[0], intensity
 
     def spaghetti_plot(self,
              path: Path,

--- a/pyspinw/lattice_distances.py
+++ b/pyspinw/lattice_distances.py
@@ -40,7 +40,6 @@ def find_relative_positions(
 
     Find all sets of fractional coordinates produced by translations of input coordinates by multiples
     of the unit cell, and that differ by a cartesian distance of a most max_distance from (0,0,0)
-    **in the positive quadrant (i>=0, j>=0, k>=0)**
 
     :param fractional_coordinates: Fractional coordinates of the base point
     :param unit_cell_transform: Transform from fractional coordinates to cartesian coordinates

--- a/pyspinw/lattice_distances.py
+++ b/pyspinw/lattice_distances.py
@@ -117,9 +117,9 @@ def get_cell_offsets_containing_bounding_box(
     limits = np.ceil(box_sizes)
 
     # Get bounds of the form [-(l+1), l+1], note that arange is not inclusive
-    i_values = np.arange(-(limits[0]+1), limits[0]+2)
-    j_values = np.arange(-(limits[1]+1), limits[1]+2)
-    k_values = np.arange(-(limits[2]+1), limits[2]+2)
+    i_values = np.arange(0, limits[0]+2)
+    j_values = np.arange(0, limits[1]+2)
+    k_values = np.arange(0, limits[2]+2)
 
     i, j, k = np.meshgrid(i_values, j_values, k_values)
 

--- a/pyspinw/lattice_distances.py
+++ b/pyspinw/lattice_distances.py
@@ -116,10 +116,10 @@ def get_cell_offsets_containing_bounding_box(
 
     limits = np.ceil(box_sizes)
 
-    # Get bounds of the form [0, l+1], note that arange is not inclusive
+    # Get bounds of the form [-(l+1), l+1], note that arange is not inclusive
     i_values = np.arange(-(limits[0]+1), limits[0]+2)
-    j_values = np.arange(-(limits[0]+1), limits[1]+2)
-    k_values = np.arange(-(limits[0]+1), limits[2]+2)
+    j_values = np.arange(-(limits[1]+1), limits[1]+2)
+    k_values = np.arange(-(limits[2]+1), limits[2]+2)
 
     i, j, k = np.meshgrid(i_values, j_values, k_values)
 

--- a/pyspinw/lattice_distances.py
+++ b/pyspinw/lattice_distances.py
@@ -52,7 +52,7 @@ def find_relative_positions(
 
     fractional_positions = fractional_coordinate_offsets + fractional_coordinates.reshape(1, 3)
 
-    cartesian_position = fractional_positions @ unit_cell_transform.T
+    cartesian_position = fractional_positions @ unit_cell_transform
 
     square_distances = np.sum(cartesian_position**2, axis=1)
 
@@ -118,9 +118,9 @@ def get_cell_offsets_containing_bounding_box(
     limits = np.ceil(box_sizes)
 
     # Get bounds of the form [0, l+1], note that arange is not inclusive
-    i_values = np.arange(0, limits[0]+2)
-    j_values = np.arange(0, limits[1]+2)
-    k_values = np.arange(0, limits[2]+2)
+    i_values = np.arange(-(limits[0]+1), limits[0]+2)
+    j_values = np.arange(-(limits[0]+1), limits[1]+2)
+    k_values = np.arange(-(limits[0]+1), limits[2]+2)
 
     i, j, k = np.meshgrid(i_values, j_values, k_values)
 

--- a/pyspinw/lattice_distances.py
+++ b/pyspinw/lattice_distances.py
@@ -40,6 +40,7 @@ def find_relative_positions(
 
     Find all sets of fractional coordinates produced by translations of input coordinates by multiples
     of the unit cell, and that differ by a cartesian distance of a most max_distance from (0,0,0)
+    **in the positive quadrant (i>=0, j>=0, k>=0)**
 
     :param fractional_coordinates: Fractional coordinates of the base point
     :param unit_cell_transform: Transform from fractional coordinates to cartesian coordinates
@@ -116,7 +117,7 @@ def get_cell_offsets_containing_bounding_box(
 
     limits = np.ceil(box_sizes)
 
-    # Get bounds of the form [-(l+1), l+1], note that arange is not inclusive
+    # Get bounds of the form [0, l+1], note that arange is not inclusive
     i_values = np.arange(0, limits[0]+2)
     j_values = np.arange(0, limits[1]+2)
     k_values = np.arange(0, limits[2]+2)

--- a/pyspinw/legacy/genmagstr.py
+++ b/pyspinw/legacy/genmagstr.py
@@ -1,11 +1,13 @@
 """ Implementation of python version of genmagstr """
-from dataclasses import dataclass
 from enum import Enum
-
+import numpy as np
 from numpy._typing import ArrayLike
+from typing import Callable
 
 from pyspinw.site import LatticeSite
 from pyspinw.symmetry.unitcell import UnitCell
+from pyspinw.structures import Structure
+from pyspinw.symmetry.supercell import TrivialSupercell, SummationSupercell, CommensuratePropagationVector
 
 
 class GenMagStrMode(Enum):
@@ -26,52 +28,75 @@ class UnitSystem(Enum):
     XYZ = 'xyz' # Cartesian
     LU = 'lu'   # Lattice units
 
-@dataclass
-class GenMagStrResult:
-    """ Result of calling genmagstr """
-
-    sites: list[LatticeSite]
-
 
 def genmagstr(
-        mode: GenMagStrMode | str,
         sites: ArrayLike | list[LatticeSite],
-        s: ArrayLike,
-        phi: float = 0.0,
-        phi_d: float = 0.0,
-        n_ext: tuple[int, int, int] = (1,1,1),
-        k: tuple[float, float, float] = (0,0,0) | None,
-        n: tuple[float, float, float] = (0,0,1),
+        unit_cell: UnitCell,
+        mode: GenMagStrMode | str,
+        phi: ArrayLike | None = None,
+        phid: ArrayLike | None = None,
+        nExt: ArrayLike | None = None,
+        k: ArrayLike | None = None,
+        n: ArrayLike | None = None,
+        S: ArrayLike | None = None,
         unit: UnitSystem | str = UnitSystem.XYZ,
-        unit_cell: UnitCell = UnitCell(1,1,1),
+        epsilon: float = 1e-5,
+        func: Callable | None = None,
+        x0: ArrayLike | None = None,
         norm: bool = True,
-        r0: bool = True):
-    """ TODO: Needs a docstring"""
-    # TODO: Make this apply to an object that contains unit cell and sites,
-    #  will depend on the output from other functions used to create sites (i.e. genlattice)
+        r0: bool = True) -> Structure:
+    """ generates a magnetic structure using Matlab-like syntax """
+    mode, unit = (GenMagStrMode(mode), UnitSystem(unit))
+
+    # Some parameter checking
+    nExt = (1,1,1) if nExt is None else tuple(*nExt)
 
     # Convert moments out of unit system to xyz
-    match unit:
-        case UnitSystem.XYZ:
-            moments = s
-        case UnitSystem.LU:
-            moments = unit_cell.fractional_to_cartesian(s)
-
+    if S is not None and unit == UnitSystem.LU:
+        S = unit_cell.fractional_to_cartesian(S)
 
     match mode:
-        case GenMagStrMode.EXTEND:
-            raise NotImplementedError("'extend' mode has been deprecated, use 'tile' instead")
+        case GenMagStrMode.TILE | GenMagStrMode.EXTEND:
+            if unit == UnitSystem.LU:
+                norm_transform = unit_cell._xyz / np.sqrt(np.sum(unit_cell._xyz**2, axis=1)).reshape(-1, 1)
+                for site in sites:
+                    Stmp = site._base_moment @ norm_transform
+                    site._base_moment = Stmp * site._magnitude / np.linalg.norm(Stmp)
+                    site._moment_data = np.array([site._base_moment])
+            return Structure(sites, unit_cell, supercell=TrivialSupercell(scaling=nExt))
+
+        case GenMagStrMode.RANDOM:
+            pass
+
+        case GenMagStrMode.HELICAL:
+            # Note: not all cases handled by Matlab are handled by this
+            if n is None or k is None:
+                raise RuntimeError('You must provide the rotation axis "n" and propagation vector "k"')
+            n = np.array(n, dtype='double')
+            norm_transform = unit_cell._xyz / np.sqrt(np.sum(unit_cell._xyz**2, axis=1)).reshape(-1, 1)
+            # Make the basis complex
+            for ii, site in enumerate(sites):
+                if S is not None:
+                    S = S * site._magnitude / np.linalg.norm(S)
+                    site._base_moment = S[:,ii] + 1j * np.cross(n, S[:,ii])
+                elif unit == UnitSystem.LU:
+                    Stmp = site._base_moment @ norm_transform
+                    Stmp = Stmp * site._magnitude / np.linalg.norm(Stmp)
+                    site._base_moment = Stmp + 1j * np.cross(n, Stmp)
+                else:
+                    site._base_moment = site._base_moment * site._magnitude / np.linalg.norm(site._base_moment)
+                    site._base_moment = site._base_moment + 1j * np.cross(n, site._base_moment)
+                site._moment_data = np.array([site._base_moment])
+            k = CommensuratePropagationVector(k[0], k[1], k[2])
+            return Structure(sites, unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
+
+        case GenMagStrMode.DIRECT:
+            raise NotImplementedError("'direct' mode to be implemented")
+
+        case GenMagStrMode.ROTATE:
+            raise NotImplementedError("'rotate' mode to be implemented")
 
         case GenMagStrMode.FUNC:
             raise NotImplementedError("'func' mode is not implemented in pySpinW, for better control over"
                                       " structures use the python interface rather than this legacy interface")
 
-        case GenMagStrMode.TILE:
-            # This is just the idenity supercell
-            pass
-
-        case GenMagStrMode.DIRECT:
-            pass
-
-        case GenMagStrMode.ROTATE:
-            pass

--- a/pyspinw/legacy/genmagstr.py
+++ b/pyspinw/legacy/genmagstr.py
@@ -39,6 +39,7 @@ def genmagstr(
         k: ArrayLike | None = None,
         n: ArrayLike | None = None,
         S: ArrayLike | None = None,
+        magnitude: ArrayLike | None = None,
         unit: UnitSystem | str = UnitSystem.XYZ,
         epsilon: float = 1e-5,
         func: Callable | None = None,
@@ -51,17 +52,27 @@ def genmagstr(
     # Some parameter checking
     nExt = (1,1,1) if nExt is None else tuple(*nExt)
 
+
     # Convert moments out of unit system to xyz
-    if S is not None and unit == UnitSystem.LU:
-        S = unit_cell.fractional_to_cartesian(S)
+    if S is not None:
+        if magnitude is None:
+            magnitude = [np.linalg.norm(S[i,:]) for i in S.shape[0]]
+        if unit == UnitSystem.LU:
+            S = unit_cell.fractional_to_cartesian(S)
+    elif magnitude is None:
+        magnitude = [np.linalg.norm(site._base_moment) for site in sites]
 
     match mode:
         case GenMagStrMode.TILE | GenMagStrMode.EXTEND:
-            if unit == UnitSystem.LU:
+            if S is not None:
+                for i, site in enumerate(sites):
+                    site._base_moment = S[i,:]
+                    site._moment_data = np.array([site._base_moment])
+            elif unit == UnitSystem.LU:
                 norm_transform = unit_cell._xyz / np.sqrt(np.sum(unit_cell._xyz**2, axis=1)).reshape(-1, 1)
-                for site in sites:
+                for i, site in enumerate(sites):
                     Stmp = site._base_moment @ norm_transform
-                    site._base_moment = Stmp * site._magnitude / np.linalg.norm(Stmp)
+                    site._base_moment = Stmp * magnitude[i] / np.linalg.norm(Stmp)
                     site._moment_data = np.array([site._base_moment])
             return Structure(sites, unit_cell, supercell=TrivialSupercell(scaling=nExt))
 
@@ -77,14 +88,14 @@ def genmagstr(
             # Make the basis complex
             for ii, site in enumerate(sites):
                 if S is not None:
-                    S = S * site._magnitude / np.linalg.norm(S)
+                    S = S * magnitude[ii] / np.linalg.norm(S)
                     site._base_moment = S[:,ii] + 1j * np.cross(n, S[:,ii])
                 elif unit == UnitSystem.LU:
                     Stmp = site._base_moment @ norm_transform
-                    Stmp = Stmp * site._magnitude / np.linalg.norm(Stmp)
+                    Stmp = Stmp * magnitude[ii] / np.linalg.norm(Stmp)
                     site._base_moment = Stmp + 1j * np.cross(n, Stmp)
                 else:
-                    site._base_moment = site._base_moment * site._magnitude / np.linalg.norm(site._base_moment)
+                    site._base_moment = site._base_moment * magnitude[ii] / np.linalg.norm(site._base_moment)
                     site._base_moment = site._base_moment + 1j * np.cross(n, site._base_moment)
                 site._moment_data = np.array([site._base_moment])
             k = CommensuratePropagationVector(k[0], k[1], k[2])

--- a/pyspinw/path.py
+++ b/pyspinw/path.py
@@ -111,7 +111,10 @@ class Path:
         if plt_or_fig is None:
             import matplotlib.pyplot as plt_or_fig
 
-        plt_or_fig.xticks(self.x_ticks(), self.x_tick_labels())
+        if hasattr(plt_or_fig, 'xticks'):
+            plt_or_fig.xticks(self.x_ticks(), self.x_tick_labels())
+        else:
+            plt_or_fig.set_xticks(self.x_ticks(), self.x_tick_labels())
 
 class Path1D():
     """ 1D Path, i.e. just values in absolute q """

--- a/pyspinw/serialisation.py
+++ b/pyspinw/serialisation.py
@@ -225,7 +225,8 @@ def numpy_serialise(data: np.ndarray) -> dict:
 
     return {
         "shape": list(shape),
-        "data": data.reshape(-1).tolist(),
+        "data": np.real(data).reshape(-1).tolist(),
+        "imag_data": np.imag(data).reshape(-1).tolist() if np.iscomplexobj(data) else None,
         "dtype": data.dtype.str
     }
 
@@ -241,7 +242,10 @@ def numpy_deserialise(json: dict) -> np.ndarray:
             if not np.all([isinstance(x, int) for x in json["data"]]):
                 raise SPWSerialisationError("Tried to make integer numpy array from non-integer data")
 
-        data = np.array(json["data"], dtype=dtype)
+        if json["imag_data"] is None:
+            data = np.array(json["data"], dtype=dtype)
+        else:
+            data = np.array(json["data"], dtype=dtype) + 1j*np.array(json["imag_data"])
 
     except KeyError as ke:
         raise SPWSerialisationError(f"Failed to deserialise numpy object, bad json keys") from ke

--- a/pyspinw/site.py
+++ b/pyspinw/site.py
@@ -3,7 +3,6 @@
 import numpy as np
 from numpy._typing import ArrayLike
 from scipy.stats import goodness_of_fit
-from enum import StrEnum
 
 from pyspinw.constants import ELECTRON_G
 from pyspinw.serialisation import SPWSerialisationContext, SPWSerialisable, SPWDeserialisationContext, \

--- a/pyspinw/site.py
+++ b/pyspinw/site.py
@@ -19,7 +19,7 @@ class LatticeSite(SPWSerialisable):
     """A spin site within a lattice
 
     :param: i,j,k - Fractional coordinates within unit cell
-    :param: mi,mj,mk - Magnetic moment along unit cell aligned axis
+    :param: mi,mj,mk - Magnetic moment (or complex basisvector) along unit cell aligned axis
     """
 
     serialisation_name = "site"
@@ -45,8 +45,7 @@ class LatticeSite(SPWSerialisable):
             self._moment_data = np.array([[
                 0.0 if mi is None else mi,
                 0.0 if mj is None else mj,
-                0.0 if mk is None else mk]],
-                    dtype=float)
+                0.0 if mk is None else mk]])
 
         else:
             if mi is not None or mj is not None or mk is not None:

--- a/pyspinw/site.py
+++ b/pyspinw/site.py
@@ -20,6 +20,10 @@ class LatticeSite(SPWSerialisable):
 
     :param: i,j,k - Fractional coordinates within unit cell
     :param: mi,mj,mk - Magnetic moment (or complex basisvector) along unit cell aligned axis
+    :param: supercell_moments - ???
+    :param: g - g-tensor (3x3)
+    :param: name
+    :param: S - magnitude of spin (optional - will be determined from mi, mj, mk components if not specified
     """
 
     serialisation_name = "site"
@@ -32,14 +36,11 @@ class LatticeSite(SPWSerialisable):
                  supercell_moments: ArrayLike | None = None,
                  g: ArrayLike | None = None,
                  name: str = "",
-                 unit: str = "xyz"):
+                 S: float | None = None):
 
         self._i = float(i)
         self._j = float(j)
         self._k = float(k)
-        if unit.lower() != "xyz" and unit.lower() != "lu":
-            raise ValueError("Unit must be either 'xyz' or 'lu'")
-        self._unit = unit.lower()
 
         #
         # Lots of case checking for the moment input format
@@ -92,7 +93,7 @@ class LatticeSite(SPWSerialisable):
                 raise ValueError("g-factor should be a scalar, a vector of length 3, or a 3-by-3 matrix")
 
         self._base_moment = np.sum(self._moment_data, axis=0)
-
+        self._magnitude = np.linalg.norm(self._base_moment) if S is None else S
         self._name = name
 
         self._ijk = np.array([i, j, k], dtype=float)
@@ -150,15 +151,9 @@ class LatticeSite(SPWSerialisable):
         return self
 
     @property
-    def unit(self):
-        """ Moment unit """
-        return self._unit
-
-    def xyz_moment(self, transformation):
-        """ The moment in XYZ unit """
-        if self.unit == 'lu':
-            return self._base_moment @ transformation
-        return self._base_moment
+    def magnitude(self):
+        """ The spin magnitude or length of this site """
+        return self._magnitude
 
     @staticmethod
     def from_coordinates(coordinates: np.ndarray, name: str = ""):
@@ -192,7 +187,7 @@ class LatticeSite(SPWSerialisable):
                 "supercell_moments": numpy_serialise(self._moment_data),
                 "name": self.name,
                 "g": numpy_serialise(self.g),
-                "unit": self.unit
+                "S": self.magnitude,
             }
 
             context.sites.put(self._unique_id, json)

--- a/pyspinw/site.py
+++ b/pyspinw/site.py
@@ -3,7 +3,7 @@
 import numpy as np
 from numpy._typing import ArrayLike
 from scipy.stats import goodness_of_fit
-from enum import Enum
+from enum import StrEnum
 
 from pyspinw.constants import ELECTRON_G
 from pyspinw.serialisation import SPWSerialisationContext, SPWSerialisable, SPWDeserialisationContext, \
@@ -16,9 +16,12 @@ def _generate_unique_id():
     _id_counter += 1
     return _id_counter
 
-class SiteMomentUnit(Enum):
+class SiteMomentUnit(StrEnum):
+    """ Moment unit: either Cartesian XYZ or lattice units LU """
+
     XYZ = "xyz"
     LU = "lu"
+
 
 class LatticeSite(SPWSerialisable):
     """A spin site within a lattice
@@ -158,6 +161,7 @@ class LatticeSite(SPWSerialisable):
         return self._unit
 
     def xyz_moment(self, transformation):
+        """ The moment in XYZ unit """
         if self.unit == SiteMomentUnit.XYZ:
             return self._base_moment @ transformation
         return self._base_moment

--- a/pyspinw/site.py
+++ b/pyspinw/site.py
@@ -16,13 +16,6 @@ def _generate_unique_id():
     _id_counter += 1
     return _id_counter
 
-class SiteMomentUnit(StrEnum):
-    """ Moment unit: either Cartesian XYZ or lattice units LU """
-
-    XYZ = "xyz"
-    LU = "lu"
-
-
 class LatticeSite(SPWSerialisable):
     """A spin site within a lattice
 
@@ -40,12 +33,14 @@ class LatticeSite(SPWSerialisable):
                  supercell_moments: ArrayLike | None = None,
                  g: ArrayLike | None = None,
                  name: str = "",
-                 unit: SiteMomentUnit | str = "xyz"):
+                 unit: str = "xyz"):
 
         self._i = float(i)
         self._j = float(j)
         self._k = float(k)
-        self._unit = SiteMomentUnit(unit) if isinstance(unit, str) else unit
+        if unit.lower() != "xyz" and unit.lower() != "lu":
+            raise ValueError("Unit must be either 'xyz' or 'lu'")
+        self._unit = unit.lower()
 
         #
         # Lots of case checking for the moment input format
@@ -162,7 +157,7 @@ class LatticeSite(SPWSerialisable):
 
     def xyz_moment(self, transformation):
         """ The moment in XYZ unit """
-        if self.unit == SiteMomentUnit.XYZ:
+        if self.unit == 'lu':
             return self._base_moment @ transformation
         return self._base_moment
 

--- a/pyspinw/site.py
+++ b/pyspinw/site.py
@@ -18,12 +18,11 @@ def _generate_unique_id():
 class LatticeSite(SPWSerialisable):
     """A spin site within a lattice
 
-    :param: i,j,k - Fractional coordinates within unit cell
+    :param: i,j,k - *required* Fractional coordinates within unit cell
     :param: mi,mj,mk - Magnetic moment (or complex basisvector) along unit cell aligned axis
-    :param: supercell_moments - ???
+    :param: supercell_moments - Magnetic moment for each propagation vector
     :param: g - g-tensor (3x3)
     :param: name
-    :param: S - magnitude of spin (optional - will be determined from mi, mj, mk components if not specified
     """
 
     serialisation_name = "site"
@@ -35,8 +34,7 @@ class LatticeSite(SPWSerialisable):
                  mk: float | None = None,
                  supercell_moments: ArrayLike | None = None,
                  g: ArrayLike | None = None,
-                 name: str = "",
-                 S: float | None = None):
+                 name: str = ""):
 
         self._i = float(i)
         self._j = float(j)
@@ -50,7 +48,8 @@ class LatticeSite(SPWSerialisable):
             self._moment_data = np.array([[
                 0.0 if mi is None else mi,
                 0.0 if mj is None else mj,
-                0.0 if mk is None else mk]])
+                0.0 if mk is None else mk]],
+                    dtype=complex)
 
         else:
             if mi is not None or mj is not None or mk is not None:
@@ -93,7 +92,6 @@ class LatticeSite(SPWSerialisable):
                 raise ValueError("g-factor should be a scalar, a vector of length 3, or a 3-by-3 matrix")
 
         self._base_moment = np.sum(self._moment_data, axis=0)
-        self._magnitude = np.linalg.norm(self._base_moment) if S is None else S
         self._name = name
 
         self._ijk = np.array([i, j, k], dtype=float)
@@ -150,11 +148,6 @@ class LatticeSite(SPWSerialisable):
         """ Get the parent site (just itself for non-implied sites)"""
         return self
 
-    @property
-    def magnitude(self):
-        """ The spin magnitude or length of this site """
-        return self._magnitude
-
     @staticmethod
     def from_coordinates(coordinates: np.ndarray, name: str = ""):
         """ Create from an array of values """
@@ -186,8 +179,7 @@ class LatticeSite(SPWSerialisable):
                 "k": self.k,
                 "supercell_moments": numpy_serialise(self._moment_data),
                 "name": self.name,
-                "g": numpy_serialise(self.g),
-                "S": self.magnitude,
+                "g": numpy_serialise(self.g)
             }
 
             context.sites.put(self._unique_id, json)

--- a/pyspinw/structures.py
+++ b/pyspinw/structures.py
@@ -44,7 +44,8 @@ class Structure(SPWSerialisable):
                 j=site.j + cell.j,
                 k=site.k + cell.k,
                 supercell_moments=site.moment_data,
-                name=site.name
+                name=site.name,
+                unit=site.unit
             ) for site in cell_sites]
 
         return all_sites
@@ -120,7 +121,8 @@ class Structure(SPWSerialisable):
                     site_1.j,
                     site_1.k,
                     supercell_moments=site_1.moment_data,
-                    name = site_1.name # TODO: Check if this is sensible
+                    name = site_1.name, # TODO: Check if this is sensible
+                    unit = site_1.unit
                 ))
 
             else:
@@ -129,7 +131,8 @@ class Structure(SPWSerialisable):
                     site_1.j,
                     site_1.k,
                     supercell_moments=np.zeros_like(site_1.moment_data),
-                    name=site_1.name  # TODO: Check if this is sensible
+                    name=site_1.name,  # TODO: Check if this is sensible
+                    unit = site_1.unit
                 ))
 
         return unique_sites
@@ -157,7 +160,8 @@ class Structure(SPWSerialisable):
                     k=position[2],
                     supercell_moments=moment,
                     g=site.g,
-                    name=site.name)
+                    name=site.name,
+                    unit=site.unit)
 
                 mapping[(site._unique_id, offset.as_tuple)] = new_site
 

--- a/pyspinw/structures.py
+++ b/pyspinw/structures.py
@@ -45,7 +45,7 @@ class Structure(SPWSerialisable):
                 k=site.k + cell.k,
                 supercell_moments=site.moment_data,
                 name=site.name,
-                unit=site.unit
+                S=site.magnitude,
             ) for site in cell_sites]
 
         return all_sites
@@ -122,7 +122,7 @@ class Structure(SPWSerialisable):
                     site_1.k,
                     supercell_moments=site_1.moment_data,
                     name = site_1.name, # TODO: Check if this is sensible
-                    unit = site_1.unit
+                    S=site_1.magnitude,
                 ))
 
             else:
@@ -132,7 +132,7 @@ class Structure(SPWSerialisable):
                     site_1.k,
                     supercell_moments=np.zeros_like(site_1.moment_data),
                     name=site_1.name,  # TODO: Check if this is sensible
-                    unit = site_1.unit
+                    S=site_1.magnitude,
                 ))
 
         return unique_sites
@@ -161,7 +161,7 @@ class Structure(SPWSerialisable):
                     supercell_moments=moment,
                     g=site.g,
                     name=site.name,
-                    unit=site.unit)
+                    S=site.magnitude)
 
                 mapping[(site._unique_id, offset.as_tuple)] = new_site
 

--- a/pyspinw/structures.py
+++ b/pyspinw/structures.py
@@ -44,8 +44,7 @@ class Structure(SPWSerialisable):
                 j=site.j + cell.j,
                 k=site.k + cell.k,
                 supercell_moments=site.moment_data,
-                name=site.name,
-                S=site.magnitude,
+                name=site.name
             ) for site in cell_sites]
 
         return all_sites
@@ -121,8 +120,7 @@ class Structure(SPWSerialisable):
                     site_1.j,
                     site_1.k,
                     supercell_moments=site_1.moment_data,
-                    name = site_1.name, # TODO: Check if this is sensible
-                    S=site_1.magnitude,
+                    name = site_1.name # TODO: Check if this is sensible
                 ))
 
             else:
@@ -131,8 +129,7 @@ class Structure(SPWSerialisable):
                     site_1.j,
                     site_1.k,
                     supercell_moments=np.zeros_like(site_1.moment_data),
-                    name=site_1.name,  # TODO: Check if this is sensible
-                    S=site_1.magnitude,
+                    name=site_1.name  # TODO: Check if this is sensible
                 ))
 
         return unique_sites
@@ -160,8 +157,7 @@ class Structure(SPWSerialisable):
                     k=position[2],
                     supercell_moments=moment,
                     g=site.g,
-                    name=site.name,
-                    S=site.magnitude)
+                    name=site.name)
 
                 mapping[(site._unique_id, offset.as_tuple)] = new_site
 

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -419,7 +419,7 @@ class SummationSupercell(CommensurateSupercell):
         moment = np.zeros(3, dtype=complex)
         for component, propagation_vector in zip(site.moment_data, self._propagation_vectors):
             # TODO: check
-            moment += np.real(component * np.exp(2j * np.pi * propagation_vector.dot(cell_offset)))
+            moment += component * np.exp(-2j * np.pi * propagation_vector.dot(cell_offset))
 
         return moment.real
 

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -246,7 +246,7 @@ class Supercell(ABC, SPWSerialisable):
     def fractional_in_supercell(self, position_in_cell: ArrayLike, cell_offset: CellOffset):
         """ Get the fractional position within a supercell """
         position = cell_offset.vector + np.array(position_in_cell, dtype=float)
-        scaling = np.array(self._scaling, dtype=float)
+        scaling = np.array(self.scaling, dtype=float)
 
         return position / scaling
 
@@ -264,9 +264,9 @@ class Supercell(ABC, SPWSerialisable):
         return {
             "type": self.supercell_name,
             "data": self._serialise_supercell(context),
-            "s_i": self._scaling[0],
-            "s_j": self._scaling[1],
-            "s_k": self._scaling[2]
+            "s_i": self.scaling[0],
+            "s_j": self.scaling[1],
+            "s_k": self.scaling[2]
         }
 
     @staticmethod
@@ -283,7 +283,9 @@ class Supercell(ABC, SPWSerialisable):
             expected_names = ", ".join([f"'{key}'" for key in supercell_types])
             raise SPWSerialisationError(f"Expected transform type to be one of {expected_names}") from ke
 
-
+    @property
+    def scaling(self):
+        return self._scaling
 
 
 class TrivialSupercell(Supercell):
@@ -344,6 +346,10 @@ class CommensurateSupercell(Supercell):
         """ Number of cells in this supercell """
         a, b, c = self.cell_size()
         return a*b*c
+
+    @property
+    def scaling(self):
+        return self.cell_size()
 
 
 class TransformationSupercell(CommensurateSupercell):

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -285,6 +285,7 @@ class Supercell(ABC, SPWSerialisable):
 
     @property
     def scaling(self):
+        """ The scaling triplet for this supercell """
         return self._scaling
 
 
@@ -349,6 +350,7 @@ class CommensurateSupercell(Supercell):
 
     @property
     def scaling(self):
+        """ The scaling triplet for this supercell """
         return self.cell_size()
 
 

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -417,7 +417,7 @@ class SummationSupercell(CommensurateSupercell):
         moment = np.zeros(3, dtype=complex)
         for component, propagation_vector in zip(site.moment_data, self._propagation_vectors):
             # TODO: check
-            moment += component * np.exp(2j * np.pi * propagation_vector.dot(cell_offset))
+            moment += np.real(component * np.exp(2j * np.pi * propagation_vector.dot(cell_offset)))
 
         return moment.real
 

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -264,9 +264,9 @@ class Supercell(ABC, SPWSerialisable):
         return {
             "type": self.supercell_name,
             "data": self._serialise_supercell(context),
-            "s_i": self.scaling[0],
-            "s_j": self.scaling[1],
-            "s_k": self.scaling[2]
+            "s_i": self._scaling[0],
+            "s_j": self._scaling[1],
+            "s_k": self._scaling[2]
         }
 
     @staticmethod

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,18 @@ impl Coupling {
             inter_site_vector: inter_site_vector.into_faer().to_owned(),
         }
     }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl PartialEq for Coupling {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.index1 == other.index1 && self.index2 == other.index2 &&
+            (self.matrix.clone() - other.matrix.clone()).norm_l1() < 1e-6 &&
+            (self.inter_site_vector.clone() - other.inter_site_vector.clone()).norm_l1() < 1e-6
+    }
 }
 
 #[pyclass(frozen)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,12 +160,9 @@ pub fn spinwave_calculation<'py>(
         .map(faer_ext::IntoFaer::into_faer)
         .collect();
 
-    let to_cart: Mat<f64> = match rlu_to_cart {
-        Some(f) => f.into_faer().to_owned(),
-        None => Mat::<f64>::identity(3, 3),
-    };
+    let to_cart: Option<MatRef<f64>> = rlu_to_cart.map(|f| f.into_faer());
 
-    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart.as_ref(), field, false);
+    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart, field, false);
     Ok((
         results
             .iter()
@@ -203,12 +200,9 @@ pub fn spinwave_calculation_Sab<'py>(
         .map(faer_ext::IntoFaer::into_faer)
         .collect();
 
-    let to_cart: Mat<f64> = match rlu_to_cart {
-        Some(f) => f.into_faer().to_owned(),
-        None => Mat::<f64>::identity(3, 3),
-    };
+    let to_cart: Option<MatRef<f64>> = rlu_to_cart.map(|f| f.into_faer());
 
-    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart.as_ref(), field, true);
+    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart, field, true);
     Ok((
         results
             .iter()

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -426,8 +426,7 @@ fn spinwave_single_q(
 
     // T is NaN if sqrt_hamiltonian is singular; add a delta to the diagonal to avoid this
     if T.has_nan() {
-        sqrt_hamiltonian.diagonal_mut().column_vector_mut().iter_mut().map(|x| {
-            if x.re.abs() < 1e-7 { C64::from(1e-7) } else { *x } });
+        sqrt_hamiltonian.diagonal_mut().column_vector_mut().iter_mut().for_each(|x| *x += C64::from(1e-7) );
         T = eigvecs * sqrt_E.as_diagonal();
         solve_upper_triangular_in_place(sqrt_hamiltonian.adjoint().as_ref(), T.as_mut(), Par::Seq);
     }

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -422,7 +422,7 @@ fn spinwave_single_q(
     // note the `faer` solver is in-place so calculates it directly on the variable `T`
     // (the input T is initially the righthand side of the equation U sqrt(E))
     let mut T = eigvecs * sqrt_E.as_diagonal();
-    solve_upper_triangular_in_place(sqrt_hamiltonian.transpose().as_ref(), T.as_mut(), Par::Seq);
+    solve_upper_triangular_in_place(sqrt_hamiltonian.adjoint().as_ref(), T.as_mut(), Par::Seq);
 
     // T is NaN if there are zero eigenvalues; set to zeroes
     if T.has_nan() {

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -439,7 +439,7 @@ fn spinwave_single_q(
     // We do the division required by 2 * n_sites here to save doing it later
     let block_diags = Mat::<Col<C64>>::from_fn(3, 3, |alpha, beta| -> Col<C64> {
         let mat = T.adjoint() * sab_blocks[(alpha, beta)].as_ref() * T.as_ref();
-        mat.diagonal().column_vector().to_owned() / (2 * n_sites) as f64
+        mat.diagonal().column_vector().to_owned() / (n_sites) as f64
     });
 
     // now create S' for each eigenvalue (the only places where there are non-zero intensities)

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -12,6 +12,7 @@ use crate::{Coupling, MagneticField, C64};
 
 /// Minimum energy that isn't just set for zero (in meV)
 const ZERO_ENERGY_TOL: f64 = 1e-12;
+const J2PI: C64 = C64::new(0., 2. * PI);
 
 /// The result of a single-Q spinwave calculation.
 ///
@@ -74,6 +75,9 @@ fn calc_q_independent(
             * (etas[c.index1].transpose() * c.matrix.as_ref() * etas[c.index2]);
     }
     C *= 2.;
+
+    // Adds a small delta to diagonal to ensure we don't have an exact degeneracies
+    C.diagonal_mut().column_vector_mut().iter_mut().enumerate().for_each(|(i, x)| *x -= C64::from((i as f64)*1e-12) );
 
     // if an external magnetic field is provided, calculate the Az matrix
     // which is added to the diagonal of A in the Hamiltonian
@@ -151,10 +155,7 @@ fn calc_sqrt_hamiltonian(
     let A_conj_minus_C: Mat<C64> = A.adjoint() - C;
     let B_adj = B.adjoint().to_owned();
 
-    // Adds a small delta to diagonal to ensure we don't have an exact degeneracies
-    let diag_delta = Mat::<C64>::from_fn(A.nrows() * 2, A.ncols() * 2,
-        |i,j| if i == j { C64::from((i as f64)*1e-12) } else { C64::ZERO } );
-    let hamiltonian: Mat<C64> = block_matrix(&A_minus_C, &B, &B_adj, &A_conj_minus_C) + diag_delta;
+    let hamiltonian: Mat<C64> = block_matrix(&A_minus_C, &B, &B_adj, &A_conj_minus_C);
 
     // take square root of Hamiltonian using Cholesky if possible; if this fails,
     // use the LDL (Bunch-Kaufmann) decomposition instead and take sqrt(H) = L * sqrt(D)
@@ -280,7 +281,7 @@ pub fn calc_spinwave(
     q_vectors: Vec<Vec<f64>>,
     couplings: Vec<&Coupling>,
     positions: Vec<ColRef<f64>>,
-    rlu_to_cart: MatRef<f64>,
+    rlu_to_cart: Option<MatRef<f64>>,
     field: Option<MagneticField>,
     save_Sab: bool,
 ) -> Vec<SpinwaveResult> {
@@ -325,7 +326,7 @@ fn spinwave_single_q(
     n_sites: usize,
     couplings: &[&Coupling],
     positions: &[ColRef<f64>],
-    rlu_to_cart: MatRef<f64>,
+    rlu_to_cart: Option<MatRef<f64>>,
     save_Sab: bool,
 ) -> SpinwaveResult {
     let z = &q_independent_components.z;
@@ -343,7 +344,6 @@ fn spinwave_single_q(
     // pair of sites i, j; to calculate these efficiently we calculate
     // exp(i q r_i) for each site i and then the outer product of this with its conjugate
     // gives us the full matrix of phase factors.
-    let J2PI = 2. * J * PI;
     let phase_factors = Col::<C64>::from_iter(
         positions
             .iter()
@@ -453,7 +453,10 @@ fn spinwave_single_q(
         .collect();
 
     // gets the conversion from r.l.u. to Cartesian, for Sperp we need Q in Cartesians
-    let qcart: Col<f64> = (q.transpose() * rlu_to_cart).transpose().to_owned();
+    let qcart: Col<f64> = match rlu_to_cart {
+        Some(m) => (q.transpose() * m).transpose().to_owned(),
+        None => q,
+    };
     
     // and finally, calculate the perpendicular component of Sab
     let intensities = {

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -439,7 +439,7 @@ fn spinwave_single_q(
     // We do the division required by 2 * n_sites here to save doing it later
     let block_diags = Mat::<Col<C64>>::from_fn(3, 3, |alpha, beta| -> Col<C64> {
         let mat = T.adjoint() * sab_blocks[(alpha, beta)].as_ref() * T.as_ref();
-        mat.diagonal().column_vector().to_owned() / (n_sites) as f64
+        mat.diagonal().column_vector().to_owned() / (2 * n_sites) as f64
     });
 
     // now create S' for each eigenvalue (the only places where there are non-zero intensities)

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -68,9 +68,9 @@ def test_find_aligned_basis_zero_is_z():
     assert np.all(e1[:, 2] == 1)
 
     assert np.all(e2[:, 0] == 0)
-    assert np.all(e2[:, 1] == 1)
+    assert np.all(e2[:, 1] == -1)
     assert np.all(e2[:, 2] == 0)
 
-    assert np.all(e3[:, 0] == -1)
+    assert np.all(e3[:, 0] == 1)
     assert np.all(e3[:, 1] == 0)
     assert np.all(e3[:, 2] == 0)

--- a/tests/test_find_distances.py
+++ b/tests/test_find_distances.py
@@ -10,7 +10,7 @@ squashed_unit_cell = UnitCell(1, 10, 10)
 
 @pytest.mark.parametrize("distance", [0.0, 0.1, 0.4])
 def test_single_distance_base_cell(distance):
-    difference = np.array([distance, 0, 0])
+    difference = np.array([-distance, 0, 0])
     output = find_relative_positions(difference, unit_cell_transform=simple_unit_cell._xyz, max_distance=0.5)
 
     assert len(output.cell_indices.reshape(-1)) == 3, "Should be one 3-vector"
@@ -20,16 +20,16 @@ def test_single_distance_base_cell(distance):
 
 @pytest.mark.parametrize("distance", [0.6, 0.9])
 def test_single_distance_neighbour_cell(distance):
-    difference = np.array([distance, 0, 0])
+    difference = np.array([-distance, 0, 0])
     output = find_relative_positions(difference, unit_cell_transform=simple_unit_cell._xyz, max_distance=0.5)
 
     assert len(output.cell_indices.reshape(-1)) == 3, "Should be one 3-vector"
     assert np.all(output.distances == 1-distance), "Should have 1 - distance"
-    assert np.all(output.cell_indices == np.array([-1,0,0])), "Should have (-1,0,0) cell offset"
+    assert np.all(output.cell_indices == np.array([1,0,0])), "Should have (1,0,0) cell offset"
 
 @pytest.mark.parametrize("distance", [0.1, 0.4, 0.6, 0.9])
 def test_double_distance(distance):
-    difference = np.array([distance, 0, 0])
+    difference = np.array([-distance, 0, 0])
     output = find_relative_positions(difference, unit_cell_transform=squashed_unit_cell._xyz, max_distance=1.0)
 
     assert len(output.cell_indices.reshape(-1)) == 6, "Should be two 3-vectors"


### PR DESCRIPTION
This PR ensures that output from PySpinW agrees with Matlab SpinW numerically. There were a couple of errors in the computations:

* A missing $`2\pi`$ in the intensity phase factor calculation
* The distance in the phase factor calculation of the Hamiltonian which we call the `inter_site_vector` is actually the vector between _unit cells_ (**G**) rather than the full vector between the sites.
* The transformation matrix T is actually `adjoint(L) \ U * sqrt(E)` rather than `L \ U * sqrt(E)` - in Matlab they use a Cholesky decomposition which yields an upper-triangular `K` whereas we use the LDL decomposition which yields a lower triangular `L` but the computation only works for an upper-triangular matrix.
* In `hamiltonian.py` the calculation of reverse couplings was missing the double counting factor of `1/2`
* The computation of distances for the couplings used the wrong transform (should not be transposed).
* The calculation of the orthogonal basis vectors `e1`, `e2`, `e3` had `e2` parallel to `[0,1,0]` if `e3` is parallel to `[1,0,0]` but the Matlab code had it parallel to `[0,0,1]` - and this caused the `kagome_supercell` calculation to fail (not sure why).
* Add code to remove duplicate couplings in the Hamiltonian calculations.

In addition, I changed the driver routines to correct the above mistakes; and also added more examples from the Matlab test suite.

However, there are two major discrepancies between the theory presented in Toth & Lake and the Matlab implementation:

1. There is an additional factor of `2` in the [Matlab Hamiltonian calculation](https://github.com/SpinW/spinw/blob/master/swfiles/%40spinw/spinwave.m#L900) of the single-ion anisotropy terms (called `A20` / `D20` in the code, [computed in lines 618-9](https://github.com/SpinW/spinw/blob/master/swfiles/%40spinw/spinwave.m#L618-L619) compared to the $`C^{i,j}`$ terms in eq (26) of the paper.
2. The scaling of the [Matlab Sab calculation (line 1096)](https://github.com/SpinW/spinw/blob/master/swfiles/%40spinw/spinwave.m#L1096-L1097) is different to equation (47) of the paper's which gives a prefactor of $`1/(2N)`$ where $`N`$ is the number of atoms in the unit cell, but the Matlab code uses `1/(2*prod(nExt))` (factor of 1/2 is in [line 1066](https://github.com/SpinW/spinw/blob/master/swfiles/%40spinw/spinwave.m#L1066)) which is the number of unit cells in the supercell - e.g. the Matlab code computes the intensity _per unit cell_ whereas the theory gives it _per magnetic atom_.

In this PR I've added code to make the Python calculations consistent with the Matlab, but we might want to make it such that it agrees with the paper instead.