### PR TITLE
Add coverage PR comment to gh-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,25 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-test.txt
-    - name: Run tests with pyTest
+    - name: Run tests with pyTest (non-Linux)
+      if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
       run: |
         python -m pytest
+    - name: Run tests with pyTest and coverage (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        coverage run --source=pyspinw -m pytest
+        echo "### Python Code Coverage: " $(coverage report | grep TOTAL | awk '{print $4}') > coverage_report.md
+        echo "<details> <summary>Coverage Files Table</summary>" >> coverage_report.md
+        echo " " >> coverage_report.md
+        coverage report --format=markdown --skip-empty -m >> coverage_report.md
+        echo "</details>" >> coverage_report.md
+    - name: Create Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && github.event_name == 'pull_request'
+      with:
+        recreate: true
+        path: coverage_report.md
 
   rust:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Run tests with pyTest and coverage (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        coverage run --source=pyspinw -m pytest
+        coverage run --source=pyspinw --omit="pyspinw/gui/*" -m pytest
         echo "### Python Code Coverage: " $(coverage report | grep TOTAL | awk '{print $4}') > coverage_report.md
         echo "<details> <summary>Coverage Files Table</summary>" >> coverage_report.md
         echo " " >> coverage_report.md

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 ruff==0.11.13
 pytest
+coverage


### PR DESCRIPTION
Adds a comment to a PR summarising test code coverage.

Note that currently the Python `spinwave.py` code is not checked because we run it in separate subprocesses using `concurrent.futures.ParallelPoolExecutor`. This PR might add an option to disable this paralellisation.

This is a very basic addition. There are other github actions which have more features such as [MishaKav](https://github.com/MishaKav/pytest-coverage-comment) or [py-cov-action](https://github.com/py-cov-action/python-coverage-comment-action). In particular they create a new branch which uploads the html coverage reports so you can browse it. There are also external services like coveralls.io or codecov.io but I didn't want to use them as it requires additional permissions and will not work for forked PRs.