### PR TITLE
Rotating Frame

### DIFF
--- a/examples/raw_calculations/triangular_antiferro.py
+++ b/examples/raw_calculations/triangular_antiferro.py
@@ -1,0 +1,67 @@
+"""Example of a triangular antiferromagnet using the rotating frame method
+
+This is the magnet in MATLAB SpinW tutorial 12:
+    https://spinw.org/tutorials/12tutorial
+"""
+import sys
+
+import numpy as np
+
+from examples.raw_calculations.utils import run_example, plot, py_classes
+from pyspinw.hamiltonian import omegasum
+
+
+def triangular_antiferro(n_q = 100, classes = py_classes):
+    """A sqrt(3) x sqrt(3) Kagome antiferromagnet supercell lattice."""
+    rust_kw = {'dtype':complex, 'order':'F'}
+    Coupling = classes.coupling
+
+    rotations = [np.array([[1, 0, 0], [0, 0, 1], [0, 1, 0]], **rust_kw)]
+    magnitudes = np.array([1.5])
+    positions = [np.array([0., 0., 0.]),]
+    couplings = [Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([ 0.,  1., 0.])),
+                 Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([ 0., -1., 0.])),
+                 Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([ 1.,  0., 0.])),
+                 Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([-1.,  0., 0.])),
+                 Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([ 1.,  1., 0.])),
+                 Coupling(0, 0, np.eye(3, **rust_kw), inter_site_vector=np.array([-1., -1., 0.])),
+                 # Final "coupling" is a planar single-ion anisotropy
+                 Coupling(0, 0, np.diag(np.array([0, 0, 0.1], **rust_kw)), inter_site_vector=np.array([0., 0., 0.]))]
+    rlu_to_cart = np.array([[2.0943951, 1.20919958, 0.], [0., 2.41839915, 0.], [0., 0., 1.57079633]], order='F')
+    field = None
+    rotating_frame = [np.array([1./3, 1./3, 1.]), np.array([0., 0., 1.])]
+
+    q_mags = np.linspace(0.01, 0.99, n_q + 1).reshape(-1, 1)
+    q_vectors = q_mags.reshape(-1, 1) * np.array([1, 1, 0]).reshape(1, -1)
+
+    return rotations, magnitudes, q_vectors, couplings, positions, rlu_to_cart, field, rotating_frame
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+
+    if len(sys.argv) > 1:
+        use_rust = "py" not in sys.argv[1]
+    else:
+        use_rust = True
+
+    structure, energies, sqw = run_example(triangular_antiferro, use_rust)
+
+    q_vectors = structure[2]
+    indices = np.arange(101)
+    label_indices = [0, 100]
+    labels = [str(q_vectors[idx, :]) for idx in label_indices]
+
+    energies = [np.sort(energy.real) for energy in energies]
+    positive_energies = [energy[energy > 0] for energy in energies]
+    min_energy = min([np.min(energy) for energy in positive_energies])
+    translated_energies = [energy - min_energy for energy in positive_energies]
+
+    # Note: we get complex data types with real part zero
+    translated_energies, sqw = omegasum(translated_energies, sqw)
+
+    fg = plot(indices, translated_energies, sqw, show=False)
+    # plt.plot(indices, [method.value for method in result.method])
+
+    #plt.savefig("fig.png")
+    fg.axes[1].set_ylim(0, 6)
+    plt.show()

--- a/examples/structures/triangular_antiferro.py
+++ b/examples/structures/triangular_antiferro.py
@@ -36,16 +36,13 @@ if __name__ == "__main__":
 
     use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
 
-    unit_cell = UnitCell(3, 3, 4, gamma=120)
+    unit_cell = UnitCell(3, 3, 8, gamma=120)
 
-    sites = [LatticeSite(0, 0, 0, 0, 1, 0, name="X")]
-    s = genmagstr(sites, unit_cell, magnitude=[3./2],mode='helical', k=[1./3, 1./3, 0], n=[0, 0, 1])
+    sites = [LatticeSite(0, 0, 0, 0, 1, 0, name="X"), LatticeSite(0, 0, 0.5, 1, 0, 0, name="X")]
+    s = genmagstr(sites, unit_cell, magnitude=[3./2, 3./2],mode='helical', k=[1./3, 1./3, 0], n=[0, 0, 1])
 
-    exchanges = couplings(sites=sites,
-                          unit_cell=unit_cell,
-                          max_distance=3.1,
-                          coupling_type=HeisenbergCoupling,
-                          j=1)
+    exchanges = couplings(sites=sites, unit_cell=unit_cell, max_distance=3.1, coupling_type=HeisenbergCoupling, j=1) \
+              + couplings(sites=sites, unit_cell=unit_cell, min_distance=3.1, max_distance=4.1, j=-0.1, coupling_type=HeisenbergCoupling)
 
     anisotropies = axis_anisotropies(sites, 0.2)
     hamiltonian = Hamiltonian(s, exchanges, anisotropies)
@@ -54,7 +51,7 @@ if __name__ == "__main__":
 
     path = Path([[0,0,0], [1,1,0]], n_points_per_segment=401)
     import matplotlib.pyplot as plt
-    fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust)
+    fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust, use_rotating=True)
     fig.axes[0].set_ylim(0, 10)
     fig.axes[1].set_ylim(0, 5)
     plt.show()

--- a/examples/structures/triangular_antiferro_rotframe.py
+++ b/examples/structures/triangular_antiferro_rotframe.py
@@ -14,20 +14,22 @@ import sys
 
 """
 tri = spinw;
-tri.genlattice('lat_const',[3 3 4],'angled',[90 90 120])
+tri.genlattice('lat_const',[3 3 8],'angled',[90 90 120])
 tri.addatom('r',[0 0 0],'S',3/2,'label','MCr3','color','orange')
+tri.addatom('r',[0 0 0.5],'S',3/2,'label','MCr3','color','orange')
 tri.gencoupling()
 tri.addmatrix('value',1,'label','J','color','SteelBlue')
 tri.addcoupling('mat','J','bond',1)
+tri.addmatrix('value',-0.1,'label','J2','color','Cyan'); tri.addcoupling('mat','J2','bond',2)
 tri.addmatrix('value',diag([0 0 0.2]),'label','D','color','r')
 tri.addaniso('D')
-tri.genmagstr('mode','helical','S',[0; 1; 0],'k',[1/3 1/3 0],'n', [0 0 1],'nExt',0.1);
-triSpec = sw_neutron(tri.spinwave({[0 0 0] [1 1 0] 500}));
+tri.genmagstr('mode','helical','S',[0 0; 1 1; 0 0],'k',[1/3 1/3 0],'n', [0 0 1])
+triSpec = sw_neutron(tri.spinwave({[0 0 0] [1 1 0] 400}));
 figure; subplot(211)
 sw_plotspec(triSpec,'mode','disp','axLim',[0 7],'colormap',[0 0 0],'colorbar',false)
 triSpec = sw_egrid(triSpec,'Evect',linspace(0,6.5,500),'component','Sperp');
 triSpec = sw_omegasum(triSpec,'zeroint',1e-6);
-subplot(212); sw_plotspec(triSpec,'mode',2,'log',false,'axLim',[0 3])
+subplot(212); sw_plotspec(triSpec,'mode',2,'log',false,'axLim',[0 5])
 """
 
 if __name__ == "__main__":
@@ -36,16 +38,13 @@ if __name__ == "__main__":
 
     use_rust = "py" not in sys.argv[1] if len(sys.argv) > 1 else True
 
-    unit_cell = UnitCell(3, 3, 4, gamma=120)
+    unit_cell = UnitCell(3, 3, 8, gamma=120)
 
-    sites = [LatticeSite(0, 0, 0, 0, 1, 0, name="X")]
-    s = genmagstr(sites, unit_cell, magnitude=[3./2],mode='helical', k=[1./3, 1./3, 0], n=[0, 0, 1])
+    sites = [LatticeSite(0, 0, 0, 0, 1, 0, name="X"), LatticeSite(0, 0, 0.5, 0, 1, 0, name="Y")]
+    s = genmagstr(sites, unit_cell, magnitude=[3./2, 3./2],mode='helical', k=[1./3, 1./3, 0], n=[0, 0, 1])
 
-    exchanges = couplings(sites=sites,
-                          unit_cell=unit_cell,
-                          max_distance=3.1,
-                          coupling_type=HeisenbergCoupling,
-                          j=1)
+    exchanges = couplings(sites=sites, unit_cell=unit_cell, max_distance=3.1, coupling_type=HeisenbergCoupling, j=1) \
+              + couplings(sites=sites, unit_cell=unit_cell, min_distance=3.1, max_distance=4.1, j=-0.1, coupling_type=HeisenbergCoupling)
 
     anisotropies = axis_anisotropies(sites, 0.2)
     hamiltonian = Hamiltonian(s, exchanges, anisotropies)
@@ -54,7 +53,7 @@ if __name__ == "__main__":
 
     path = Path([[0,0,0], [1,1,0]], n_points_per_segment=401)
     import matplotlib.pyplot as plt
-    fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust)
-    fig.axes[0].set_ylim(0, 10)
+    fig = hamiltonian.spaghetti_plot(path, show=False, use_rust=use_rust, use_rotating=True)
+    fig.axes[0].set_ylim(0, 7)
     fig.axes[1].set_ylim(0, 5)
     plt.show()

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -213,6 +213,7 @@ def spinwave_calculation(
         positions: list[np.ndarray],
         rlu_to_cart: np.ndarray = np.eye(3),
         field: MagneticField | None = None,
+        sab_transform: list[np.ndarray] | None = None,
         save_sab: bool = False) -> tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
     """Calculate the energies and spin-spin correlation for a set of q-vectors."""
     C, z, spin_coefficients, Az = _calc_q_independent(rotations, magnitudes, couplings, field)
@@ -225,7 +226,7 @@ def spinwave_calculation(
         q_calculations = [
             executor.submit(
                 _calc_chunk_spinwave, q, C, n_sites, z, spin_coefficients, couplings, positions,
-                rlu_to_cart, Az, save_sab
+                rlu_to_cart, sab_transform, Az, save_sab
             )
             for q in _get_q_chunks(q_vectors, n_proc)
         ]
@@ -259,6 +260,7 @@ def _calc_chunk_spinwave(
         couplings: list[Coupling],
         positions: list[np.ndarray],
         rlu_to_cart: np.ndarray,
+        sab_transform: list[np.ndarray] | None = None,
         Az: np.ndarray | None = None,
         save_sab: bool = False) \
             -> tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
@@ -266,6 +268,11 @@ def _calc_chunk_spinwave(
     energies = []
     intensities = []
     sabs = []
+
+    if sab_transform is not None:
+        sab_transform, nmat, nxn, km = tuple(sab_transform)
+    else:
+        km = np.array([0, 0, 0])
 
     for q in q_vectors:
         sqrt_hamiltonian = _calc_sqrt_hamiltonian(q, C, n_sites, z, spin_coefficients, couplings, Az)
@@ -343,11 +350,19 @@ def _calc_chunk_spinwave(
         sab = np.array([[np.diag(T.conj().T @ sab_blocks[alpha, beta] @ T) for alpha in range(3)] for beta in range(3)])
         sab /= 2 * n_sites
 
+        if sab_transform is not None:
+            # Convert back into lab frame (eq 37)
+            sab = 0.5 * (sab - np.einsum("ij,jkl,km->iml", nmat, sab, nmat)
+                             + np.einsum("ij,jkl,km->iml", nxn-np.eye(3), sab, nxn)
+                             + np.einsum("ij,jkl,km->iml", nxn, sab, 2*nxn-np.eye(3)))
+            # Apply the transformation (eq 40)
+            sab = np.einsum("ijk,jl->ilk", sab, sab_transform)
+
         # take perpendicular component s_perp of sab
         if (q_mag := np.linalg.norm(q)) == 0:
             norm_q = np.array([0, 0, 0])
         else:
-            norm_q = q @ rlu_to_cart
+            norm_q = (q-km) @ rlu_to_cart
             norm_q /= np.sqrt(np.sum(norm_q**2))
         perp_factor = np.eye(3) - np.outer(norm_q, norm_q)
         # the einsum here performs elementwise multiplication and then sums over alpha, beta

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -213,20 +213,33 @@ def spinwave_calculation(
         positions: list[np.ndarray],
         rlu_to_cart: np.ndarray = np.eye(3),
         field: MagneticField | None = None,
-        sab_transform: list[np.ndarray] | None = None,
+        rotating_frame: list[np.ndarray] | None = None,
         save_sab: bool = False) -> tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
     """Calculate the energies and spin-spin correlation for a set of q-vectors."""
+    if rotating_frame is not None:
+        km, nvec = tuple(rotating_frame)
+        # Computes the transformation matrices for Sab after Toth & Lake, eq (39)
+        nmat = np.array([[0, -nvec[2], nvec[1]], [nvec[2], 0, -nvec[0]], [-nvec[1], nvec[0], 0]])
+        R2 = np.outer(nvec, nvec)
+        R1 = (np.eye(3) - 1j*nmat - R2) / 2.
+        rotating_frame = (nmat, R1, R2, km)
+        # Transforms the coupling matrices after Toth & Lake, eq (21)
+        for coupling in couplings:
+            qdotr = 2 * np.pi * np.dot(km, coupling.inter_site_vector)
+            Rq = (np.eye(3) * np.cos(qdotr)) + (nmat * np.sin(qdotr)) + (R2 * (1 - np.cos(qdotr))) # R(Q.r_n) eq (39)
+            coupling.matrix = (coupling.matrix @ Rq + Rq @ coupling.matrix) / 2.
+
     C, z, spin_coefficients, Az = _calc_q_independent(rotations, magnitudes, couplings, field)
     n_sites = len(rotations)
 
     # Linear algebra routines in numpy are already parallelised and usually use 4 cores
     # for a single process, so we want to reduce contention by using fewer processes.
-    n_proc = max(int(np.floor(multiprocessing.cpu_count() / 4)), 1)
+    n_proc = 1#max(int(np.floor(multiprocessing.cpu_count() / 4)), 1)
     with ProcessPoolExecutor() as executor:
         q_calculations = [
             executor.submit(
                 _calc_chunk_spinwave, q, C, n_sites, z, spin_coefficients, couplings, positions,
-                rlu_to_cart, sab_transform, Az, save_sab
+                rlu_to_cart, rotating_frame, Az, save_sab
             )
             for q in _get_q_chunks(q_vectors, n_proc)
         ]
@@ -260,21 +273,21 @@ def _calc_chunk_spinwave(
         couplings: list[Coupling],
         positions: list[np.ndarray],
         rlu_to_cart: np.ndarray,
-        sab_transform: list[np.ndarray] | None = None,
+        rotating_frame: list[np.ndarray] | None = None,
         Az: np.ndarray | None = None,
         save_sab: bool = False) \
             -> tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
     """Calculate the energies and S'^alpha,beta for a chunk of q-values."""
     energies = []
     intensities = []
-    sabs = []
 
-    if sab_transform is not None:
-        sab_transform, nmat, nxn, km = tuple(sab_transform)
-    else:
-        km = np.array([0, 0, 0])
+    if rotating_frame is not None:
+        nmat, R1, nxn, km = tuple(rotating_frame)
+        q_vectors = np.vstack([q_vectors-km, q_vectors, q_vectors+km])
 
-    for q in q_vectors:
+    sabs = np.empty((3, 3, 2*n_sites, q_vectors.shape[0]), dtype=complex)
+
+    for ii, q in enumerate(q_vectors):
         sqrt_hamiltonian = _calc_sqrt_hamiltonian(q, C, n_sites, z, spin_coefficients, couplings, Az)
 
         sqrt_hamiltonian_with_commutation = sqrt_hamiltonian.copy()
@@ -349,24 +362,32 @@ def _calc_chunk_spinwave(
         # this is a 3x3x2N array indexed by [alpha, beta, omega]
         sab = np.array([[np.diag(T.conj().T @ sab_blocks[alpha, beta] @ T) for alpha in range(3)] for beta in range(3)])
         sab /= 2 * n_sites
+        sabs[:,:,:,ii] = sab
 
-        if sab_transform is not None:
-            # Convert back into lab frame (eq 37)
-            sab = 0.5 * (sab - np.einsum("ij,jkl,km->iml", nmat, sab, nmat)
-                             + np.einsum("ij,jkl,km->iml", nxn-np.eye(3), sab, nxn)
-                             + np.einsum("ij,jkl,km->iml", nxn, sab, 2*nxn-np.eye(3)))
-            # Apply the transformation (eq 40)
-            sab = np.einsum("ijk,jl->ilk", sab, sab_transform)
+    if rotating_frame is not None:
+        # Convert back into lab frame (eq 37)
+        sabs = 0.5 * (sabs - np.einsum("ij,jklm,kn->inlm", nmat, sabs, nmat)
+                           + np.einsum("ij,jklm,kn->inlm", nxn-np.eye(3), sabs, nxn)
+                           + np.einsum("ij,jklm,kn->inlm", nxn, sabs, 2*nxn-np.eye(3)))
+        # Apply the rotation transformation (eq 40)
+        nq = int(q_vectors.shape[0] / 3)
+        sabs = np.concatenate([np.einsum("ijkl,jm->imkl", sabs[:,:,:,:nq], R1.conj()),
+                               np.einsum("ijkl,jm->imkl", sabs[:,:,:,nq:2*nq], nxn),
+                               np.einsum("ijkl,jm->imkl", sabs[:,:,:,2*nq:], R1)], axis=2)
+        energies = [np.hstack([energies[i], energies[nq+i], energies[2*nq+i]]) for i in range(nq)]
+        # Reset q vectors list for next loop
+        q_vectors = q_vectors[nq:2*nq,:]
 
+    for ii, q in enumerate(q_vectors):
         # take perpendicular component s_perp of sab
         if (q_mag := np.linalg.norm(q)) == 0:
             norm_q = np.array([0, 0, 0])
         else:
-            norm_q = (q-km) @ rlu_to_cart
+            norm_q = q @ rlu_to_cart
             norm_q /= np.sqrt(np.sum(norm_q**2))
         perp_factor = np.eye(3) - np.outer(norm_q, norm_q)
         # the einsum here performs elementwise multiplication and then sums over alpha, beta
-        s_perp = np.einsum("ijk,ij->k", sab, perp_factor)
+        s_perp = np.einsum("ijk,ij->k", sabs[:,:,:,ii], perp_factor)
         intensities.append(s_perp)
 
     if save_sab:

--- a/pyspinw/calculations/spinwave.py
+++ b/pyspinw/calculations/spinwave.py
@@ -234,7 +234,7 @@ def spinwave_calculation(
 
     # Linear algebra routines in numpy are already parallelised and usually use 4 cores
     # for a single process, so we want to reduce contention by using fewer processes.
-    n_proc = 1#max(int(np.floor(multiprocessing.cpu_count() / 4)), 1)
+    n_proc = max(int(np.floor(multiprocessing.cpu_count() / 4)), 1)
     with ProcessPoolExecutor() as executor:
         q_calculations = [
             executor.submit(

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -213,23 +213,22 @@ class Hamiltonian(SPWSerialisable):
 
         rust_kw = {'dtype': complex, 'order': 'F'}
 
-        # default to using the rotating frame method if we can, otherwise warn and switch to supercell calculation
-        if use_rotating:
-            if not hasattr(self.structure.supercell, '_propagation_vectors'):
-                use_rotating = False  # Cannot use because supercell has no propagation vectors
-            elif not (hasattr(self.structure.supercell, 'perpendicular') and
-                      len(self.structure.supercell._propagation_vectors) == 1):
-                logger.warning("Could not use rotating frame calculation as no plane normal specified")
-                use_rotating = False
-
         #
         # Set up the system
         #
-        if use_rotating:
-            expanded, scaling = (self, 1.)
-            nvec = self.structure.supercell.perpendicular
-            rotating_frame = [self.structure.supercell._propagation_vectors[0]._vector, nvec / np.linalg.norm(nvec)]
+        if all([hasattr(self.structure.supercell, v) for v in ['propagation_vector', 'perpendicular']]):
+            if use_rotating:
+                expanded, scaling = (self, 1.)
+                nvec = self.structure.supercell.perpendicular
+                rotating_frame = [self.structure.supercell.propagation_vector._vector, nvec / np.linalg.norm(nvec)]
+            else:
+                newstruc = Structure(**{k:getattr(self.structure, k) for k in ['sites', 'unit_cell', 'spacegroup']},
+                               supercell=self.structure.supercell.approximant())
+                expanded = Hamiltonian(newstruc, self.couplings, self.anisotropies).expanded()
+                scaling, rotating_frame = (newstruc.supercell.scaling, None)
         else:
+            if use_rotating:
+                logger.warning("Cannot do rotating frame calculation propagation vector or plane normal not specified")
             expanded, scaling, rotating_frame = (self.expanded(), self.structure.supercell.scaling, None)
 
         # Get the positions, rotations, moments for the sites

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -308,12 +308,49 @@ class Hamiltonian(SPWSerialisable):
 
         return result[0], intensity
 
+    @check_sizes(q_vectors=(-1, 3), field=(3,), allow_nones=True, force_numpy=True)
+    def rotating_frame_calculator(self, q_vectors: np.ndarray, field: ArrayLike | None = None, use_rust: bool=True):
+        """Calculate the energy levels of the system for the given q-vectors."""
+        if not (hasattr(self.structure.supercell, '_propagation_vectors') and
+            hasattr(self.structure.supercell, 'perpendicular') and
+            len(self.structure.supercell._propagation_vectors) == 1):
+            raise RuntimeError('This method only works for rotation supercells with a single propagation vector')
+        # Computes the transformation matrices for Sab after Toth & Lake, eq (39)
+        nvec = self.structure.supercell.perpendicular / np.linalg.norm(self.structure.supercell.perpendicular)
+        nmat = np.array([[0, -nvec[2], nvec[1]], [nvec[2], 0, -nvec[0]], [-nvec[1], nvec[0], 0]])
+        R2 = np.outer(nvec, nvec)
+        R1 = (np.eye(3) - 1j*nmat - R2) / 2.
+        # Transforms the coupling matrices after Toth & Lake, eq (21) 
+        new_couplings = []
+        q = self.structure.supercell._propagation_vectors[0]
+        for coupling in self.couplings:
+            qdotr = 2 * np.pi * q.dot(coupling.cell_offset)
+            Rq = (np.eye(3) * np.cos(qdotr)) + (nmat * np.sin(qdotr)) + (R2 * (1 - np.cos(qdotr)))  #  R(Q.r_n) in eq (39)
+            new_matrix = (coupling.coupling_matrix @ Rq + Rq @ coupling.coupling_matrix) / 2.
+            new_couplings.append(Coupling(coupling.site_1, coupling.site_2, coupling.cell_offset, new_matrix, coupling.name))
+        new_ham = Hamiltonian(structure=self.structure, couplings=new_couplings, anisotropies=self.anisotropies)
+        # Converts inputs into raw arrays for calculators
+        rotations, magnitudes, couplings, positions, magnetic_field, calculator = \
+            new_ham.prepare_spinwave_calculation(field, use_rust)
+        # Calculates S(Q-k), S(Q) and S(Q+k)
+        kvec = self.structure.supercell._propagation_vectors[0]._vector
+        inputs = {'rotations':rotations, 'magnitudes':magnitudes, 'couplings':couplings, 'positions':positions,
+                  'field':magnetic_field, 'rlu_to_cart':np.linalg.inv(self.structure.unit_cell._xyz).T * 2 * np.pi}
+        resm = calculator(q_vectors=q_vectors - kvec, sab_transform=[R1.conj(), nmat, R2, -kvec], **inputs)
+        res0 = calculator(q_vectors=q_vectors, sab_transform=[R2, nmat, R2, np.array([0,0,0])], **inputs)
+        resp = calculator(q_vectors=q_vectors + kvec, sab_transform=[R1, nmat, R2, kvec], **inputs)
+        # Rescales intensity from per atom to per cell to agree with Matlab code for Sab
+        intensity = np.hstack([[res * rotations.shape[0] for res in r[1]] for r in [resm, res0, resp]])
+        return np.hstack((resm[0], res0[0], resp[0])), intensity
+
+
     def spaghetti_plot(self,
              path: Path,
              field: ArrayLike | None = None,
              show: bool=True,
              new_figure: bool=True,
              use_rust: bool=True,
+             use_rotating: bool=False,
              scale: str='linear'):
         """ Create a spaghetti diagram with energy top and intensity bottom """
         if new_figure:

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -29,7 +29,7 @@ from pyspinw.symmetry.supercell import TrivialSupercell
 
 logger = logging.Logger("pyspinw.hamiltonian")
 
-def omegasum(energy, intensity, tol=1e-5, zeroint=0):
+def omegasum(energy: ArrayLike, intensity: ArrayLike, tol: float=1e-5, zeroint: int=0):
     """ Removes degenerate and ghost (zero-intensity) modes from spectrum """
     energy, intensity = (np.array(energy), np.array(intensity))
     en_out, int_out = (energy * np.nan, intensity * np.nan)
@@ -175,9 +175,9 @@ class Hamiltonian(SPWSerialisable):
         """ Print a textual summary to stdout"""
         print(self.text_summary)
 
-    @check_sizes(q_vectors=(-1, 3), field=(3,), allow_nones=True, force_numpy=True)
-    def energies_and_intensities(self, q_vectors: np.ndarray, field: ArrayLike | None = None, use_rust: bool=True):
-        """Calculate the energy levels of the system for the given q-vectors."""
+    @check_sizes(field=(3,), allow_nones=True, force_numpy=True)
+    def prepare_spinwave_calculation(self, field: ArrayLike | None = None, use_rust: bool=True):
+        """ Sets up data structures for a spinwave calculation """
         #
         # Set up choice of calculation
         #
@@ -212,13 +212,11 @@ class Hamiltonian(SPWSerialisable):
         # Set up the system
         #
 
-        expanded = self.expanded()
-
         # Get the positions, rotations, moments for the sites
         moments = []
         positions = []
         unique_id_to_index: dict[int, int] = {}
-        for index, site in enumerate(expanded._structure.sites):
+        for index, site in enumerate(self.structure.sites):
             # TODO: Sort out moments for supercells
             moments.append(site.base_moment)
 
@@ -231,9 +229,8 @@ class Hamiltonian(SPWSerialisable):
             magnetic_field = None
         else:
             g_tensors = []
-            for site in expanded.structure.sites:
+            for site in self.structure.sites:
                 g_tensors.append(site.g)
-
             magnetic_field = magnetic_field_class(
                                 vector=np.array(field, **rust_kw),
                                 g_tensors=np.array(g_tensors, **rust_kw))
@@ -245,7 +242,7 @@ class Hamiltonian(SPWSerialisable):
 
         # Convert the couplings
         couplings: list[Coupling] = []
-        for input_coupling in expanded.couplings:
+        for input_coupling in self.couplings:
             # Normal coupling
 
             # Factor of 1/2 is due to double counting correction
@@ -274,7 +271,7 @@ class Hamiltonian(SPWSerialisable):
                      if all([c1 != c2 for c2 in couplings[ic+1:]])]
 
         # Add in anisotropies as spinwave_calculation couplings
-        for input_anisotropy in expanded.anisotropies:
+        for input_anisotropy in self.anisotropies:
 
             anisotropy = coupling_class(
                 unique_id_to_index[input_anisotropy.site._unique_id],
@@ -285,7 +282,17 @@ class Hamiltonian(SPWSerialisable):
 
             couplings.append(anisotropy)
 
-        result = spinwave_calculation(
+        return rotations, magnitudes, couplings, positions, magnetic_field, spinwave_calculation
+
+    @check_sizes(q_vectors=(-1, 3), field=(3,), allow_nones=True, force_numpy=True)
+    def energies_and_intensities(self, q_vectors: np.ndarray, field: ArrayLike | None = None, use_rust: bool=True):
+        """Calculate the energy levels of the system for the given q-vectors."""
+        # Set up the system
+        expanded = self.expanded()
+        rotations, magnitudes, couplings, positions, magnetic_field, calculator = \
+            expanded.prepare_spinwave_calculation(field, use_rust)
+
+        result = calculator(
                         rotations=rotations,
                         magnitudes=magnitudes,
                         q_vectors=q_vectors * self.structure.supercell.scaling,
@@ -318,7 +325,8 @@ class Hamiltonian(SPWSerialisable):
                 axs.append(fig.add_subplot(2,1,ii+1))
 
         x_values = path.x_values()
-        energy, intensity = omegasum(*self.energies_and_intensities(path.q_points(), field=field, use_rust=use_rust))
+        calculator = self.rotating_frame_calculator if use_rotating else self.energies_and_intensities
+        energy, intensity = omegasum(*calculator(path.q_points(), field=field, use_rust=use_rust))
         n_mode = energy.shape[1]
         for series in zip(*([v[:, n_mode - i - 1] for i in range(n_mode)] for v in (energy, intensity))):
             axs[0].plot(x_values, series[0], 'k')

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -175,9 +175,14 @@ class Hamiltonian(SPWSerialisable):
         """ Print a textual summary to stdout"""
         print(self.text_summary)
 
-    @check_sizes(field=(3,), allow_nones=True, force_numpy=True)
-    def prepare_spinwave_calculation(self, field: ArrayLike | None = None, use_rust: bool=True):
-        """ Sets up data structures for a spinwave calculation """
+    @check_sizes(q_vectors=(-1, 3), field=(3,), allow_nones=True, force_numpy=True)
+    def energies_and_intensities(self,
+                                 q_vectors: np.ndarray,
+                                 field: ArrayLike | None = None,
+                                 use_rust: bool=True,
+                                 use_rotating: bool=True,
+                                 ):
+        """Calculate the energy levels of the system for the given q-vectors."""
         #
         # Set up choice of calculation
         #
@@ -208,15 +213,30 @@ class Hamiltonian(SPWSerialisable):
 
         rust_kw = {'dtype': complex, 'order': 'F'}
 
+        # default to using the rotating frame method if we can, otherwise warn and switch to supercell calculation
+        if use_rotating:
+            if not hasattr(self.structure.supercell, '_propagation_vectors'):
+                use_rotating = False  # Cannot use because supercell has no propagation vectors
+            elif not (hasattr(self.structure.supercell, 'perpendicular') and
+                      len(self.structure.supercell._propagation_vectors) == 1):
+                logger.warning("Could not use rotating frame calculation as no plane normal specified")
+                use_rotating = False
+
         #
         # Set up the system
         #
+        if use_rotating:
+            expanded, scaling = (self, 1.)
+            nvec = self.structure.supercell.perpendicular
+            rotating_frame = [self.structure.supercell._propagation_vectors[0]._vector, nvec / np.linalg.norm(nvec)]
+        else:
+            expanded, scaling, rotating_frame = (self.expanded(), self.structure.supercell.scaling, None)
 
         # Get the positions, rotations, moments for the sites
         moments = []
         positions = []
         unique_id_to_index: dict[int, int] = {}
-        for index, site in enumerate(self.structure.sites):
+        for index, site in enumerate(expanded.structure.sites):
             # TODO: Sort out moments for supercells
             moments.append(site.base_moment)
 
@@ -229,7 +249,7 @@ class Hamiltonian(SPWSerialisable):
             magnetic_field = None
         else:
             g_tensors = []
-            for site in self.structure.sites:
+            for site in expanded.structure.sites:
                 g_tensors.append(site.g)
             magnetic_field = magnetic_field_class(
                                 vector=np.array(field, **rust_kw),
@@ -242,10 +262,9 @@ class Hamiltonian(SPWSerialisable):
 
         # Convert the couplings
         couplings: list[Coupling] = []
-        for input_coupling in self.couplings:
+        for input_coupling in expanded.couplings:
             # Normal coupling
 
-            # Factor of 1/2 is due to double counting correction
             coupling = coupling_class(
                 unique_id_to_index[input_coupling.site_1._unique_id],
                 unique_id_to_index[input_coupling.site_2._unique_id],
@@ -271,78 +290,34 @@ class Hamiltonian(SPWSerialisable):
                      if all([c1 != c2 for c2 in couplings[ic+1:]])]
 
         # Add in anisotropies as spinwave_calculation couplings
-        for input_anisotropy in self.anisotropies:
+        for input_anisotropy in expanded.anisotropies:
 
             anisotropy = coupling_class(
                 unique_id_to_index[input_anisotropy.site._unique_id],
                 unique_id_to_index[input_anisotropy.site._unique_id],
+                # Factor 2 here is to agree with Matlab code (need to check if is correct)
                 np.array(input_anisotropy.anisotropy_matrix.T, **rust_kw) * 2.,
                 inter_site_vector=np.array([0,0,0], dtype=float)
             )
 
             couplings.append(anisotropy)
 
-        return rotations, magnitudes, couplings, positions, magnetic_field, spinwave_calculation
-
-    @check_sizes(q_vectors=(-1, 3), field=(3,), allow_nones=True, force_numpy=True)
-    def energies_and_intensities(self, q_vectors: np.ndarray, field: ArrayLike | None = None, use_rust: bool=True):
-        """Calculate the energy levels of the system for the given q-vectors."""
-        # Set up the system
-        expanded = self.expanded()
-        rotations, magnitudes, couplings, positions, magnetic_field, calculator = \
-            expanded.prepare_spinwave_calculation(field, use_rust)
-
-        result = calculator(
+        result = spinwave_calculation(
                         rotations=rotations,
                         magnitudes=magnitudes,
-                        q_vectors=q_vectors * self.structure.supercell.scaling,
+                        q_vectors=q_vectors * scaling,
                         couplings=couplings,
                         positions=positions,
                         rlu_to_cart=np.linalg.inv(self.structure.unit_cell._xyz).T * 2 * np.pi,
-                        field=magnetic_field)
+                        field=magnetic_field,
+                        rotating_frame=rotating_frame)
 
         # Applies a rescaling to agree with Matlab code for Sab
         # Toth & Lake eq (46) gives a 1/(2Natom) prefactor but the Matlab code uses 1/(2*Ncell)
-        scale_factor = rotations.shape[0] / np.prod(self.structure.supercell.scaling)
+        scale_factor = rotations.shape[0] / np.prod(scaling)
         intensity = [res * scale_factor for res in result[1]]
 
         return result[0], intensity
-
-    @check_sizes(q_vectors=(-1, 3), field=(3,), allow_nones=True, force_numpy=True)
-    def rotating_frame_calculator(self, q_vectors: np.ndarray, field: ArrayLike | None = None, use_rust: bool=True):
-        """Calculate the energy levels of the system for the given q-vectors."""
-        if not (hasattr(self.structure.supercell, '_propagation_vectors') and
-            hasattr(self.structure.supercell, 'perpendicular') and
-            len(self.structure.supercell._propagation_vectors) == 1):
-            raise RuntimeError('This method only works for rotation supercells with a single propagation vector')
-        # Computes the transformation matrices for Sab after Toth & Lake, eq (39)
-        nvec = self.structure.supercell.perpendicular / np.linalg.norm(self.structure.supercell.perpendicular)
-        nmat = np.array([[0, -nvec[2], nvec[1]], [nvec[2], 0, -nvec[0]], [-nvec[1], nvec[0], 0]])
-        R2 = np.outer(nvec, nvec)
-        R1 = (np.eye(3) - 1j*nmat - R2) / 2.
-        # Transforms the coupling matrices after Toth & Lake, eq (21) 
-        new_couplings = []
-        q = self.structure.supercell._propagation_vectors[0]
-        for coupling in self.couplings:
-            qdotr = 2 * np.pi * q.dot(coupling.cell_offset)
-            Rq = (np.eye(3) * np.cos(qdotr)) + (nmat * np.sin(qdotr)) + (R2 * (1 - np.cos(qdotr)))  #  R(Q.r_n) in eq (39)
-            new_matrix = (coupling.coupling_matrix @ Rq + Rq @ coupling.coupling_matrix) / 2.
-            new_couplings.append(Coupling(coupling.site_1, coupling.site_2, coupling.cell_offset, new_matrix, coupling.name))
-        new_ham = Hamiltonian(structure=self.structure, couplings=new_couplings, anisotropies=self.anisotropies)
-        # Converts inputs into raw arrays for calculators
-        rotations, magnitudes, couplings, positions, magnetic_field, calculator = \
-            new_ham.prepare_spinwave_calculation(field, use_rust)
-        # Calculates S(Q-k), S(Q) and S(Q+k)
-        kvec = self.structure.supercell._propagation_vectors[0]._vector
-        inputs = {'rotations':rotations, 'magnitudes':magnitudes, 'couplings':couplings, 'positions':positions,
-                  'field':magnetic_field, 'rlu_to_cart':np.linalg.inv(self.structure.unit_cell._xyz).T * 2 * np.pi}
-        resm = calculator(q_vectors=q_vectors - kvec, sab_transform=[R1.conj(), nmat, R2, -kvec], **inputs)
-        res0 = calculator(q_vectors=q_vectors, sab_transform=[R2, nmat, R2, np.array([0,0,0])], **inputs)
-        resp = calculator(q_vectors=q_vectors + kvec, sab_transform=[R1, nmat, R2, kvec], **inputs)
-        # Rescales intensity from per atom to per cell to agree with Matlab code for Sab
-        intensity = np.hstack([[res * rotations.shape[0] for res in r[1]] for r in [resm, res0, resp]])
-        return np.hstack((resm[0], res0[0], resp[0])), intensity
-
 
     def spaghetti_plot(self,
              path: Path,
@@ -362,8 +337,8 @@ class Hamiltonian(SPWSerialisable):
                 axs.append(fig.add_subplot(2,1,ii+1))
 
         x_values = path.x_values()
-        calculator = self.rotating_frame_calculator if use_rotating else self.energies_and_intensities
-        energy, intensity = omegasum(*calculator(path.q_points(), field=field, use_rust=use_rust))
+        energy, intensity = omegasum(*self.energies_and_intensities(path.q_points(),
+                                     field=field, use_rust=use_rust, use_rotating=use_rotating))
         n_mode = energy.shape[1]
         for series in zip(*([v[:, n_mode - i - 1] for i in range(n_mode)] for v in (energy, intensity))):
             axs[0].plot(x_values, series[0], 'k')

--- a/pyspinw/legacy/genmagstr.py
+++ b/pyspinw/legacy/genmagstr.py
@@ -89,7 +89,6 @@ def genmagstr(
             if S is not None or unit == UnitSystem.LU:
                 _convert_moments()
             n = np.array(n, dtype='double')
-            k = CommensuratePropagationVector(k[0], k[1], k[2])
             return Structure(sites, unit_cell, supercell=RotationSupercell(perpendicular=n, propagation_vector=k))
 
         case GenMagStrMode.DIRECT:

--- a/pyspinw/legacy/genmagstr.py
+++ b/pyspinw/legacy/genmagstr.py
@@ -7,7 +7,7 @@ from typing import Callable
 from pyspinw.site import LatticeSite
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
-from pyspinw.symmetry.supercell import TrivialSupercell, SummationSupercell, CommensuratePropagationVector
+from pyspinw.symmetry.supercell import TrivialSupercell, RotationSupercell, SummationSupercell, CommensuratePropagationVector
 
 
 class GenMagStrMode(Enum):
@@ -99,7 +99,7 @@ def genmagstr(
                     site._base_moment = site._base_moment + 1j * np.cross(n, site._base_moment)
                 site._moment_data = np.array([site._base_moment])
             k = CommensuratePropagationVector(k[0], k[1], k[2])
-            return Structure(sites, unit_cell, supercell=SummationSupercell(propagation_vectors=[k]))
+            return Structure(sites, unit_cell, supercell=RotationSupercell(perpendicular=n, propagation_vector=k))
 
         case GenMagStrMode.DIRECT:
             raise NotImplementedError("'direct' mode to be implemented")

--- a/pyspinw/legacy/genmagstr.py
+++ b/pyspinw/legacy/genmagstr.py
@@ -7,7 +7,8 @@ from typing import Callable
 from pyspinw.site import LatticeSite
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.structures import Structure
-from pyspinw.symmetry.supercell import TrivialSupercell, RotationSupercell, SummationSupercell, CommensuratePropagationVector
+from pyspinw.symmetry.supercell import (TrivialSupercell, RotationSupercell, SummationSupercell,
+    CommensuratePropagationVector)
 
 
 class GenMagStrMode(Enum):
@@ -62,18 +63,20 @@ def genmagstr(
     elif magnitude is None:
         magnitude = [np.linalg.norm(site._base_moment) for site in sites]
 
+    def _convert_moments():
+        norm_transform = unit_cell._xyz / np.sqrt(np.sum(unit_cell._xyz**2, axis=1)).reshape(-1, 1)
+        for i, site in enumerate(sites):
+            if S is not None:
+                site._base_moment = S[i,:] * magnitude[ii] / np.linalg.norm(S[i,:])
+            elif unit == UnitSystem.LU:
+                Stmp = site._base_moment @ norm_transform
+                site._base_moment = Stmp * magnitude[i] / np.linalg.norm(Stmp)
+            site._moment_data = np.array([site._base_moment])
+
     match mode:
         case GenMagStrMode.TILE | GenMagStrMode.EXTEND:
-            if S is not None:
-                for i, site in enumerate(sites):
-                    site._base_moment = S[i,:]
-                    site._moment_data = np.array([site._base_moment])
-            elif unit == UnitSystem.LU:
-                norm_transform = unit_cell._xyz / np.sqrt(np.sum(unit_cell._xyz**2, axis=1)).reshape(-1, 1)
-                for i, site in enumerate(sites):
-                    Stmp = site._base_moment @ norm_transform
-                    site._base_moment = Stmp * magnitude[i] / np.linalg.norm(Stmp)
-                    site._moment_data = np.array([site._base_moment])
+            if S is not None or unit == UnitSystem.LU:
+                _convert_moments()
             return Structure(sites, unit_cell, supercell=TrivialSupercell(scaling=nExt))
 
         case GenMagStrMode.RANDOM:
@@ -83,21 +86,9 @@ def genmagstr(
             # Note: not all cases handled by Matlab are handled by this
             if n is None or k is None:
                 raise RuntimeError('You must provide the rotation axis "n" and propagation vector "k"')
+            if S is not None or unit == UnitSystem.LU:
+                _convert_moments()
             n = np.array(n, dtype='double')
-            norm_transform = unit_cell._xyz / np.sqrt(np.sum(unit_cell._xyz**2, axis=1)).reshape(-1, 1)
-            # Make the basis complex
-            for ii, site in enumerate(sites):
-                if S is not None:
-                    S = S * magnitude[ii] / np.linalg.norm(S)
-                    site._base_moment = S[:,ii] + 1j * np.cross(n, S[:,ii])
-                elif unit == UnitSystem.LU:
-                    Stmp = site._base_moment @ norm_transform
-                    Stmp = Stmp * magnitude[ii] / np.linalg.norm(Stmp)
-                    site._base_moment = Stmp + 1j * np.cross(n, Stmp)
-                else:
-                    site._base_moment = site._base_moment * magnitude[ii] / np.linalg.norm(site._base_moment)
-                    site._base_moment = site._base_moment + 1j * np.cross(n, site._base_moment)
-                site._moment_data = np.array([site._base_moment])
             k = CommensuratePropagationVector(k[0], k[1], k[2])
             return Structure(sites, unit_cell, supercell=RotationSupercell(perpendicular=n, propagation_vector=k))
 

--- a/pyspinw/site.py
+++ b/pyspinw/site.py
@@ -19,7 +19,7 @@ class LatticeSite(SPWSerialisable):
     """A spin site within a lattice
 
     :param: i,j,k - *required* Fractional coordinates within unit cell
-    :param: mi,mj,mk - Magnetic moment (or complex basisvector) along unit cell aligned axis
+    :param: mi,mj,mk - Magnetic moment along unit cell aligned axis
     :param: supercell_moments - Magnetic moment for each propagation vector
     :param: g - g-tensor (3x3)
     :param: name
@@ -49,7 +49,7 @@ class LatticeSite(SPWSerialisable):
                 0.0 if mi is None else mi,
                 0.0 if mj is None else mj,
                 0.0 if mk is None else mk]],
-                    dtype=complex)
+                    dtype=float)
 
         else:
             if mi is not None or mj is not None or mk is not None:

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -439,6 +439,7 @@ class SummationSupercell(CommensurateSupercell):
 
 class RotationSupercell(CommensurateSupercell):
     """ A supercell defined by moments which rotates in a plane and a single propagation vector """
+
     supercell_name = "rotation"
 
     def __init__(self, perpendicular: ArrayLike, propagation_vector: ArrayLike | CommensuratePropagationVector):
@@ -448,6 +449,7 @@ class RotationSupercell(CommensurateSupercell):
         self.perpendicular = perpendicular
 
     def moment(self, site: LatticeSite, cell_offset: CellOffset):
+        """ Calculate moment at a given cell offset"""
         basis = site.moment_data + 1j * np.cross(self.perpendicular, site.moment_data)
         return basis * np.exp(-2j * np.pi * self._propagation_vectors[0].dot(cell_offset))
 
@@ -456,7 +458,7 @@ class RotationSupercell(CommensurateSupercell):
         raise NotImplementedError("Not implemented yet")
 
     def _serialise_supercell(self, context: SPWSerialisationContext):
-        return [{"vector": self._propagation_vectors[0]._serialise(context), 
+        return [{"vector": self._propagation_vectors[0]._serialise(context),
                  "perpendicular": numpy_serialise(self.perpendicular)}]
 
     @staticmethod

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -438,7 +438,7 @@ class SummationSupercell(CommensurateSupercell):
 
 
 class RotationSupercell(CommensurateSupercell):
-    """ A supercell defined by moments which rotated in a plane and a single propagation vector """
+    """ A supercell defined by moments which rotates in a plane and a single propagation vector """
     supercell_name = "rotation"
 
     def __init__(self, perpendicular: ArrayLike, propagation_vector: ArrayLike | CommensuratePropagationVector):
@@ -448,8 +448,8 @@ class RotationSupercell(CommensurateSupercell):
         self.perpendicular = perpendicular
 
     def moment(self, site: LatticeSite, cell_offset: CellOffset):
-        basis = site.moment_data + 1j * np.cross(perpendicular, site.moment_data)
-        return basis * np.exp(-2j * np.pi * propagation_vector.dot(cell_offset))
+        basis = site.moment_data + 1j * np.cross(self.perpendicular, site.moment_data)
+        return basis * np.exp(-2j * np.pi * self._propagation_vectors[0].dot(cell_offset))
 
     def summation_form(self) -> "Supercell":
         """ Convert into summation form """

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -94,19 +94,15 @@ class CommensuratePropagationVector(PropagationVector):
     """ Propagation vector with rational values"""
 
     def __init__(self,
-                 i: Fraction | float | PropagationVector,
-                 j: Fraction | float | None = None,
-                 k: Fraction | float | None = None,
-                 phase: float = 0.0):
+                 i: Fraction | float,
+                 j: Fraction | float,
+                 k: Fraction | float,
+                 phase: float = 0.0,
+                 max_denominator=1000):
 
-        if isinstance(i, PropagationVector):
-            i, j, k, phase = (i.i, i.j, i.k, i.phase)
-        elif j is None or k is None:
-            raise RuntimeError('Missing j and k components')
-
-        i = _coerce_numeric_input(i)
-        j = _coerce_numeric_input(j)
-        k = _coerce_numeric_input(k)
+        i = _coerce_numeric_input(i, max_denominator)
+        j = _coerce_numeric_input(j, max_denominator)
+        k = _coerce_numeric_input(k, max_denominator)
 
         super().__init__(i, j, k, phase=phase)
 
@@ -467,9 +463,15 @@ class RotationSupercell(Supercell):
         """ Convert into summation form """
         raise NotImplementedError("Not implemented yet")
 
-    def approximant(self) -> TransformationSupercell:
+    def approximant(self, max_denominator: int = 1000) -> TransformationSupercell:
         """ Convert to an approximate commensurate supercell """
-        k = CommensuratePropagationVector(self.propagation_vector)
+        k = CommensuratePropagationVector(
+            i=self.propagation_vector.i,
+            j=self.propagation_vector.j,
+            k=self.propagation_vector.k,
+            phase=self.propagation_vector.phase,
+            max_denominator=max_denominator)
+        
         return TransformationSupercell([(k, RotationTransform(self.perpendicular))])
 
     def _serialise_supercell(self, context: SPWSerialisationContext):

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -94,10 +94,15 @@ class CommensuratePropagationVector(PropagationVector):
     """ Propagation vector with rational values"""
 
     def __init__(self,
-                 i: Fraction | float,
-                 j: Fraction | float,
-                 k: Fraction | float,
+                 i: Fraction | float | PropagationVector,
+                 j: Fraction | float | None = None,
+                 k: Fraction | float | None = None,
                  phase: float = 0.0):
+
+        if isinstance(i, PropagationVector):
+            i, j, k, phase = (i.i, i.j, i.k, i.phase)
+        elif j is None or k is None:
+            raise RuntimeError('Missing j and k components')
 
         i = _coerce_numeric_input(i)
         j = _coerce_numeric_input(j)
@@ -437,28 +442,38 @@ class SummationSupercell(CommensurateSupercell):
         return SummationSupercell(vectors, scale)
 
 
-class RotationSupercell(CommensurateSupercell):
+class RotationSupercell(Supercell):
     """ A supercell defined by moments which rotates in a plane and a single propagation vector """
 
     supercell_name = "rotation"
 
-    def __init__(self, perpendicular: ArrayLike, propagation_vector: ArrayLike | CommensuratePropagationVector):
-        if not isinstance(propagation_vector, CommensuratePropagationVector):
-            propagation_vector = CommensuratePropagationVector(*propagation_vector)
-        super().__init__([propagation_vector], (1, 1, 1))
+    def __init__(self, perpendicular: ArrayLike, propagation_vector: ArrayLike | PropagationVector):
+        if not isinstance(propagation_vector, PropagationVector):
+            propagation_vector = PropagationVector(*propagation_vector)
+        super().__init__((1, 1, 1))
         self.perpendicular = perpendicular
+        self.propagation_vector = propagation_vector
 
     def moment(self, site: LatticeSite, cell_offset: CellOffset):
         """ Calculate moment at a given cell offset"""
         basis = site.moment_data + 1j * np.cross(self.perpendicular, site.moment_data)
-        return basis * np.exp(-2j * np.pi * self._propagation_vectors[0].dot(cell_offset))
+        return basis * np.exp(-2j * np.pi * self.propagation_vector.dot(cell_offset))
+
+    def cell_size(self) -> tuple[int, int, int]:
+        """ How big is this supercell """
+        return (1, 1, 1)
 
     def summation_form(self) -> "Supercell":
         """ Convert into summation form """
         raise NotImplementedError("Not implemented yet")
 
+    def approximant(self) -> TransformationSupercell:
+        """ Convert to an approximate commensurate supercell """
+        k = CommensuratePropagationVector(self.propagation_vector)
+        return TransformationSupercell([(k, RotationTransform(self.perpendicular))])
+
     def _serialise_supercell(self, context: SPWSerialisationContext):
-        return [{"vector": self._propagation_vectors[0]._serialise(context),
+        return [{"vector": self.propagation_vector._serialise(context),
                  "perpendicular": numpy_serialise(self.perpendicular)}]
 
     @staticmethod

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -471,7 +471,7 @@ class RotationSupercell(Supercell):
             k=self.propagation_vector.k,
             phase=self.propagation_vector.phase,
             max_denominator=max_denominator)
-        
+
         return TransformationSupercell([(k, RotationTransform(self.perpendicular))])
 
     def _serialise_supercell(self, context: SPWSerialisationContext):

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -436,5 +436,35 @@ class SummationSupercell(CommensurateSupercell):
         vectors = [PropagationVector._deserialise(data, context) for data in json["vectors"]]
         return SummationSupercell(vectors, scale)
 
+
+class RotationSupercell(CommensurateSupercell):
+    """ A supercell defined by moments which rotated in a plane and a single propagation vector """
+    supercell_name = "rotation"
+
+    def __init__(self, perpendicular: ArrayLike, propagation_vector: ArrayLike | CommensuratePropagationVector):
+        if not isinstance(propagation_vector, CommensuratePropagationVector):
+            propagation_vector = CommensuratePropagationVector(*propagation_vector)
+        super().__init__([propagation_vector], (1, 1, 1))
+        self.perpendicular = perpendicular
+
+    def moment(self, site: LatticeSite, cell_offset: CellOffset):
+        basis = site.moment_data + 1j * np.cross(perpendicular, site.moment_data)
+        return basis * np.exp(-2j * np.pi * propagation_vector.dot(cell_offset))
+
+    def summation_form(self) -> "Supercell":
+        """ Convert into summation form """
+        raise NotImplementedError("Not implemented yet")
+
+    def _serialise_supercell(self, context: SPWSerialisationContext):
+        return [{"vector": self._propagation_vectors[0]._serialise(context), 
+                 "perpendicular": numpy_serialise(self.perpendicular)}]
+
+    @staticmethod
+    def _deserialise_supercell(json, scale, context):
+        perpendicular = numpy_deserialise(json['perpendicular'])
+        propagation_vector = PropagationVector._deserialise(json["vector"], context)
+        return RotationSupercell(perpendicular, propagation_vector)
+
+
 supercell_types = {cls.supercell_name: cls
-                   for cls in [TrivialSupercell, TransformationSupercell, SummationSupercell]}
+                   for cls in [TrivialSupercell, TransformationSupercell, SummationSupercell, RotationSupercell]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,10 @@ impl Coupling {
 impl PartialEq for Coupling {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.index1 == other.index1 && self.index2 == other.index2 &&
-            (self.matrix.clone() - other.matrix.clone()).norm_l1() < 1e-6 &&
-            (self.inter_site_vector.clone() - other.inter_site_vector.clone()).norm_l1() < 1e-6
+        self.index1 == other.index1
+            && self.index2 == other.index2
+            && (self.matrix.clone() - other.matrix.clone()).norm_l1() < 1e-6
+            && (self.inter_site_vector.clone() - other.inter_site_vector.clone()).norm_l1() < 1e-6
     }
 }
 
@@ -162,10 +163,20 @@ pub fn spinwave_calculation<'py>(
         .collect();
 
     let to_cart: Option<MatRef<f64>> = rlu_to_cart.map(|f| f.into_faer());
-    let rotating: Option<Vec<ColRef<f64>>> = rotating_frame
-        .map(|f| f.into_iter().map(faer_ext::IntoFaer::into_faer).collect());
+    let rotating: Option<Vec<ColRef<f64>>> =
+        rotating_frame.map(|f| f.into_iter().map(faer_ext::IntoFaer::into_faer).collect());
 
-    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart, field, rotating, false);
+    let results = calc_spinwave(
+        r,
+        magnitudes,
+        q_vectors.clone(),
+        c,
+        p,
+        to_cart,
+        field,
+        rotating,
+        false,
+    );
     Ok((
         results
             .iter()
@@ -205,10 +216,20 @@ pub fn spinwave_calculation_Sab<'py>(
         .collect();
 
     let to_cart: Option<MatRef<f64>> = rlu_to_cart.map(|f| f.into_faer());
-    let rotating: Option<Vec<ColRef<f64>>> = rotating_frame
-        .map(|f| f.into_iter().map(faer_ext::IntoFaer::into_faer).collect());
+    let rotating: Option<Vec<ColRef<f64>>> =
+        rotating_frame.map(|f| f.into_iter().map(faer_ext::IntoFaer::into_faer).collect());
 
-    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart, field, rotating, true);
+    let results = calc_spinwave(
+        r,
+        magnitudes,
+        q_vectors.clone(),
+        c,
+        p,
+        to_cart,
+        field,
+        rotating,
+        true,
+    );
     Ok((
         results
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub fn energies<'py>(
 /// - A list of 1D numpy arrays, each containing the energies for the corresponding q-vector.
 /// - A list of 1D numpy arrays, each containing the neutron scattering cross-section
 ///   for the corresponding q-vector (indexed over omega).
-#[pyfunction(signature = (rotations, magnitudes, q_vectors, couplings, positions, rlu_to_cart=None, field=None))]
+#[pyfunction(signature = (rotations, magnitudes, q_vectors, couplings, positions, rlu_to_cart=None, field=None, rotating_frame=None))]
 pub fn spinwave_calculation<'py>(
     py: Python<'py>,
     rotations: Vec<PyReadonlyArray2<C64>>,
@@ -146,6 +146,7 @@ pub fn spinwave_calculation<'py>(
     positions: Vec<PyReadonlyArray1<f64>>,
     rlu_to_cart: Option<PyReadonlyArray2<f64>>,
     field: Option<MagneticField>,
+    rotating_frame: Option<Vec<PyReadonlyArray1<f64>>>,
 ) -> PyResult<(Energies<'py>, SQw<'py>)> {
     // convert PyO3-friendly array types to faer matrices
     let r: Vec<MatRef<C64>> = rotations
@@ -161,8 +162,10 @@ pub fn spinwave_calculation<'py>(
         .collect();
 
     let to_cart: Option<MatRef<f64>> = rlu_to_cart.map(|f| f.into_faer());
+    let rotating: Option<Vec<ColRef<f64>>> = rotating_frame
+        .map(|f| f.into_iter().map(faer_ext::IntoFaer::into_faer).collect());
 
-    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart, field, false);
+    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart, field, rotating, false);
     Ok((
         results
             .iter()
@@ -176,7 +179,7 @@ pub fn spinwave_calculation<'py>(
 }
 
 /// Same as spinwave_calculation but also returns Sab tensors.
-#[pyfunction(signature = (rotations, magnitudes, q_vectors, couplings, positions, rlu_to_cart=None, field=None))]
+#[pyfunction(signature = (rotations, magnitudes, q_vectors, couplings, positions, rlu_to_cart=None, field=None, rotating_frame=None))]
 pub fn spinwave_calculation_Sab<'py>(
     py: Python<'py>,
     rotations: Vec<PyReadonlyArray2<C64>>,
@@ -186,6 +189,7 @@ pub fn spinwave_calculation_Sab<'py>(
     positions: Vec<PyReadonlyArray1<f64>>,
     rlu_to_cart: Option<PyReadonlyArray2<f64>>,
     field: Option<MagneticField>,
+    rotating_frame: Option<Vec<PyReadonlyArray1<f64>>>,
 ) -> PyResult<(Energies<'py>, SQw<'py>, SabTensor<'py>)> {
     // convert PyO3-friendly array types to faer matrices
     let r: Vec<MatRef<C64>> = rotations
@@ -201,8 +205,10 @@ pub fn spinwave_calculation_Sab<'py>(
         .collect();
 
     let to_cart: Option<MatRef<f64>> = rlu_to_cart.map(|f| f.into_faer());
+    let rotating: Option<Vec<ColRef<f64>>> = rotating_frame
+        .map(|f| f.into_iter().map(faer_ext::IntoFaer::into_faer).collect());
 
-    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart, field, true);
+    let results = calc_spinwave(r, magnitudes, q_vectors.clone(), c, p, to_cart, field, rotating, true);
     Ok((
         results
             .iter()

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -1,8 +1,8 @@
 use std::f64::consts::PI;
 
 use faer::linalg::triangular_solve::solve_upper_triangular_in_place;
-use faer::{unzip, zip, Col, ColRef, Mat, MatRef, Par, Side, perm, mat};
-use faer::mat::{AsMatRef, AsMatMut};
+use faer::mat::{AsMatMut, AsMatRef};
+use faer::{mat, perm, unzip, zip, Col, ColRef, Mat, MatRef, Par, Side};
 use indicatif::ParallelProgressIterator;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
@@ -90,7 +90,11 @@ fn calc_q_independent(
     C *= 2.;
 
     // Adds a small delta to diagonal to ensure we don't have an exact degeneracies
-    C.diagonal_mut().column_vector_mut().iter_mut().enumerate().for_each(|(i, x)| *x -= C64::from((i as f64)*1e-12) );
+    C.diagonal_mut()
+        .column_vector_mut()
+        .iter_mut()
+        .enumerate()
+        .for_each(|(i, x)| *x -= C64::from((i as f64) * 1e-12));
 
     // if an external magnetic field is provided, calculate the Az matrix
     // which is added to the diagonal of A in the Hamiltonian
@@ -188,9 +192,14 @@ fn calc_sqrt_hamiltonian(
             zip!(&mut sqrt_d, d).for_each(|unzip!(sqd, v)| *sqd = v.sqrt());
             // need to apply permutations: in Python scipy does this for you
             let mut shm = Mat::<C64>::zeros(l.nrows(), l.ncols());
-            perm::permute_cols(shm.as_mat_mut(), (ldl.P().inverse() * l * sqrt_d.as_diagonal()).as_mat_ref(), ldl.P().inverse());
+            perm::permute_cols(
+                shm.as_mat_mut(),
+                (ldl.P().inverse() * l * sqrt_d.as_diagonal()).as_mat_ref(),
+                ldl.P().inverse(),
+            );
             shm
-        }} 
+        }
+    }
 }
 
 /// Calculate energies (eigenvalues of the Hamiltonian) for a set of q-vectors.
@@ -310,13 +319,19 @@ pub fn calc_spinwave(
             let km: Col<f64> = rot_comps[0].to_owned();
             let n = Col::<C64>::from_iter(rot_comps[1].iter().map(|f| C64::new(*f, 0.)));
             // Computes the rotation matrices in Toth & Lake eq 39
-            let nx = mat![[C64::ZERO, -n[2], n[1]], [n[2], C64::ZERO, -n[0]], [-n[1], n[0], C64::ZERO]];
+            let nx = mat![
+                [C64::ZERO, -n[2], n[1]],
+                [n[2], C64::ZERO, -n[0]],
+                [-n[1], n[0], C64::ZERO]
+            ];
             let R2 = n.clone() * n.transpose();
             let R1 = (Mat::<C64>::identity(3, 3) - (nx.as_ref() * SCALAR_J) - R2.as_ref()) / 2.;
             new_couplings = Vec::from_iter(couplings.iter().map(|c| {
                 let phi = 2. * PI * km.transpose() * c.inter_site_vector.as_ref();
                 // R is the Rodrigues rotation matrix
-                let R = Mat::<C64>::identity(3, 3) * phi.cos() + &nx * phi.sin() + (1. - phi.cos()) * &R2;
+                let R = Mat::<C64>::identity(3, 3) * phi.cos()
+                    + &nx * phi.sin()
+                    + (1. - phi.cos()) * &R2;
                 Coupling {
                     index1: c.index1,
                     index2: c.index2,
@@ -324,9 +339,9 @@ pub fn calc_spinwave(
                     inter_site_vector: c.inter_site_vector.clone(),
                 }
             }));
-            couplings = Vec::from_iter(new_couplings.iter().map(|f| f));
+            couplings = Vec::from_iter(new_couplings.iter());
             Some(RotatingFrameComponents { km, nx, R1, R2 })
-        },
+        }
         _ => None,
     };
 
@@ -339,26 +354,36 @@ pub fn calc_spinwave(
             .progress_count(n_q)
             .map(|q| {
                 let q_vec = Col::from_iter(q);
-                (-1..=1).into_par_iter().map(|tri_id| {
-                    spinwave_single_q(
-                        q_vec.clone(),
-                        &QIndependentComponents,
-                        n_sites,
-                        &couplings,
-                        &positions,
-                        rlu_to_cart,
-                        &rotating_components,
-                        save_Sab,
-                        tri_id as f64,
+                (-1..=1)
+                    .into_par_iter()
+                    .map(|tri_id| {
+                        spinwave_single_q(
+                            q_vec.clone(),
+                            &QIndependentComponents,
+                            n_sites,
+                            &couplings,
+                            &positions,
+                            rlu_to_cart,
+                            &rotating_components,
+                            save_Sab,
+                            tri_id as f64,
+                        )
+                    })
+                    .reduce_with(
+                        |mut triplet_results: SpinwaveResult, result: SpinwaveResult| {
+                            triplet_results.energies.extend(result.energies);
+                            if save_Sab {
+                                triplet_results
+                                    .sab
+                                    .as_mut()
+                                    .unwrap()
+                                    .extend(result.sab.unwrap());
+                            }
+                            triplet_results.intensities.extend(result.intensities);
+                            triplet_results
+                        },
                     )
-                }).reduce_with(|mut triplet_results: SpinwaveResult, result: SpinwaveResult| {
-                        triplet_results.energies.extend(result.energies);
-                        if save_Sab {
-                            triplet_results.sab.as_mut().unwrap().extend(result.sab.unwrap());
-                        }
-                        triplet_results.intensities.extend(result.intensities);
-                        triplet_results
-                }).unwrap() 
+                    .unwrap()
             })
             .collect()
     } else {
@@ -413,7 +438,7 @@ fn spinwave_single_q(
     let spin_coefficients = &q_independent_components.spin_coefficients;
 
     if let Some(rotcomp) = rotating_components {
-        q = q + tri_id * rotcomp.km.as_ref();
+        q += tri_id * rotcomp.km.as_ref();
     }
 
     let mut sqrt_hamiltonian =
@@ -479,7 +504,8 @@ fn spinwave_single_q(
         }
     }
 
-    let eigendecomp = (sqrt_hamiltonian.adjoint() * shc).self_adjoint_eigen(Side::Lower)
+    let eigendecomp = (sqrt_hamiltonian.adjoint() * shc)
+        .self_adjoint_eigen(Side::Lower)
         .expect("Could not calculate eigendecomposition of the Hamiltonian.");
 
     let eigvals: ColRef<C64> = eigendecomp.S().column_vector();
@@ -512,7 +538,11 @@ fn spinwave_single_q(
 
     // T is NaN if sqrt_hamiltonian is singular; add a delta to the diagonal to avoid this
     if T.has_nan() {
-        sqrt_hamiltonian.diagonal_mut().column_vector_mut().iter_mut().for_each(|x| *x += C64::from(1e-7) );
+        sqrt_hamiltonian
+            .diagonal_mut()
+            .column_vector_mut()
+            .iter_mut()
+            .for_each(|x| *x += C64::from(1e-7));
         T = eigvecs * sqrt_E.as_diagonal();
         solve_upper_triangular_in_place(sqrt_hamiltonian.adjoint().as_ref(), T.as_mut(), Par::Seq);
     }
@@ -541,18 +571,23 @@ fn spinwave_single_q(
         // Convert back into lab frame (eq 37)
         let R2I = &rotcomp.R2 - Mat::<C64>::identity(3, 3);
         let R22I = (2. * &rotcomp.R2) - Mat::<C64>::identity(3, 3);
-        Sab.iter_mut().for_each(|m| *m = 0.5 * (&*m - (&rotcomp.nx * &*m * &rotcomp.nx)
-                                                    + (&R2I * &*m * &rotcomp.R2)
-                                                    + (&rotcomp.R2 * &*m * &R22I)));
+        Sab.iter_mut().for_each(|m| {
+            *m = 0.5
+                * (&*m - (&rotcomp.nx * &*m * &rotcomp.nx)
+                    + (&R2I * &*m * &rotcomp.R2)
+                    + (&rotcomp.R2 * &*m * &R22I))
+        });
         // Apply the rotation transformation (eq 40)
         match tri_id {
-            n if n < 0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R1.conjugate()),
+            n if n < 0. => Sab
+                .iter_mut()
+                .for_each(|m| *m = &*m * rotcomp.R1.conjugate()),
             n if n > 0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R1),
-            n if n == 0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R2),
+            0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R2),
             _ => panic!(),
         }
         // Convert q back for qperp calculation
-        q = q - tri_id * rotcomp.km.as_ref();
+        q -= tri_id * rotcomp.km.as_ref();
     }
 
     // gets the conversion from r.l.u. to Cartesian, for Sperp we need Q in Cartesians
@@ -560,10 +595,13 @@ fn spinwave_single_q(
         Some(m) => (q.transpose() * m).transpose().to_owned(),
         None => q,
     };
-    
+
     // and finally, calculate the perpendicular component of Sab
     let intensities = {
-        let mut norm_q: Col<C64> = (qcart.as_ref() / qcart.norm_l2()).iter().map(C64::from).collect();
+        let mut norm_q: Col<C64> = (qcart.as_ref() / qcart.norm_l2())
+            .iter()
+            .map(C64::from)
+            .collect();
         if norm_q.has_nan() {
             norm_q = Col::<C64>::from_iter([C64::ZERO, C64::ZERO, C64::ZERO]);
         }

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -366,20 +366,18 @@ fn spinwave_triq(
 ) -> SpinwaveResult {
     match rot {
         Some(..) => {
-            let Sm = spinwave_single_q(q.clone(), &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, -1.);
-            let S0 = spinwave_single_q(q.clone(), &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, 0.);
-            let Sp = spinwave_single_q(q.clone(), &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, 1.);
-            let sab: Option<Vec<Mat<C64>>> = match save_Sab {
-                true => {
-                    Some(vec![Sm.sab.unwrap(), S0.sab.unwrap(), Sp.sab.unwrap()].concat())
-                },
-                false => None,
-            };
-            SpinwaveResult {
-                energies: vec![Sm.energies, S0.energies, Sp.energies].concat(),
-                sab: sab,
-                intensities: vec![Sm.intensities, S0.intensities, Sp.intensities].concat(),
-            }
+            // triplet IDs are -1, 0, 1 corresponding to the three components of the rotating frame
+            // transformation; we map over all three in parallel then concatenate the results
+            (-1..=1).into_par_iter().map(|tri_id| {
+                spinwave_single_q(q.clone(), &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, tri_id as f64)
+            }).reduce_with(|mut triplet_results: SpinwaveResult, result: SpinwaveResult| {
+                        triplet_results.energies.extend(result.energies);
+                        if save_Sab {
+                            triplet_results.sab.as_mut().unwrap().extend(result.sab.unwrap());
+                        }
+                        triplet_results.intensities.extend(result.intensities);
+                        triplet_results
+                }).unwrap() 
         },
         _ => spinwave_single_q(q, &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, 0.),
     }

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -325,7 +325,7 @@ pub fn calc_spinwave(
                 }
             }));
             couplings = Vec::from_iter(new_couplings.iter().map(|f| f));
-            Some(RotatingFrameComponents { km: km, nx: nx, R1: R1, R2: R2 })
+            Some(RotatingFrameComponents { km, nx, R1, R2 })
         },
         _ => None,
     };

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -6,14 +6,13 @@ use faer::mat::{AsMatRef, AsMatMut};
 use indicatif::ParallelProgressIterator;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-use crate::constants::{J, MU_B};
+use crate::constants::{J, MU_B, SCALAR_J};
 use crate::utils::*;
 use crate::{Coupling, MagneticField, C64};
 
 /// Minimum energy that isn't just set for zero (in meV)
 const ZERO_ENERGY_TOL: f64 = 1e-12;
 const J2PI: C64 = C64::new(0., 2. * PI);
-const C0: C64 = C64::new(0., 0.);
 
 /// The result of a single-Q spinwave calculation.
 ///
@@ -311,10 +310,9 @@ pub fn calc_spinwave(
             let km: Col<f64> = rot_comps[0].to_owned();
             let n = Col::<C64>::from_iter(rot_comps[1].iter().map(|f| C64::new(*f, 0.)));
             // Computes the rotation matrices in Toth & Lake eq 39
-            let iNx = mat![[C0, -n[2] * J, n[1] * J], [n[2] * J, C0, -n[0] * J], [-n[1] * J, n[0] * J, C0]];
-            let nx = mat![[C0, -n[2], n[1]], [n[2], C0, -n[0]], [-n[1], n[0], C0]];
-            let R2 = n.clone().as_mat() * n.as_mat().transpose();
-            let R1 = (Mat::<C64>::identity(3, 3) - iNx.as_ref() - R2.as_ref()) / 2.;
+            let nx = mat![[C64::ZERO, -n[2], n[1]], [n[2], C64::ZERO, -n[0]], [-n[1], n[0], C64::ZERO]];
+            let R2 = n.clone() * n.transpose();
+            let R1 = (Mat::<C64>::identity(3, 3) - (nx.as_ref() * SCALAR_J) - R2.as_ref()) / 2.;
             new_couplings = Vec::from_iter(couplings.iter().map(|c| {
                 let phi = 2. * PI * km.transpose() * c.inter_site_vector.as_ref();
                 // R is the Rodrigues rotation matrix
@@ -334,43 +332,26 @@ pub fn calc_spinwave(
 
     let QIndependentComponents = calc_q_independent(rotations, magnitudes, &couplings, field);
 
-    q_vectors
-        .into_par_iter()
-        .progress_count(n_q)
-        .map(|q| {
-            spinwave_triq(
-                Col::from_iter(q),
-                &QIndependentComponents,
-                n_sites,
-                &couplings,
-                &positions,
-                rlu_to_cart,
-                &rotating_components,
-                save_Sab,
-            )
-        })
-        .collect()
-}
-
-/// Caculate energies and intensities for a triplet of q-vectors (rotating frame)
-/// For non-rotating frame calculations, just calls spinwave_single_q
-fn spinwave_triq(
-    q: Col<f64>,
-    q_indep: &QIndependentComponents,
-    n_sites: usize,
-    couplings: &[&Coupling],
-    pos: &[ColRef<f64>],
-    rlu_to_cart: Option<MatRef<f64>>,
-    rot: &Option<RotatingFrameComponents>,
-    save_Sab: bool,
-) -> SpinwaveResult {
-    match rot {
-        Some(..) => {
-            // triplet IDs are -1, 0, 1 corresponding to the three components of the rotating frame
-            // transformation; we map over all three in parallel then concatenate the results
-            (-1..=1).into_par_iter().map(|tri_id| {
-                spinwave_single_q(q.clone(), &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, tri_id as f64)
-            }).reduce_with(|mut triplet_results: SpinwaveResult, result: SpinwaveResult| {
+    if rotating_components.is_some() {
+        // Caculate energies and intensities for a triplet of q-vectors in a rotating frame
+        q_vectors
+            .into_par_iter()
+            .progress_count(n_q)
+            .map(|q| {
+                let q_vec = Col::from_iter(q);
+                (-1..=1).into_par_iter().map(|tri_id| {
+                    spinwave_single_q(
+                        q_vec.clone(),
+                        &QIndependentComponents,
+                        n_sites,
+                        &couplings,
+                        &positions,
+                        rlu_to_cart,
+                        &rotating_components,
+                        save_Sab,
+                        tri_id as f64,
+                    )
+                }).reduce_with(|mut triplet_results: SpinwaveResult, result: SpinwaveResult| {
                         triplet_results.energies.extend(result.energies);
                         if save_Sab {
                             triplet_results.sab.as_mut().unwrap().extend(result.sab.unwrap());
@@ -378,8 +359,26 @@ fn spinwave_triq(
                         triplet_results.intensities.extend(result.intensities);
                         triplet_results
                 }).unwrap() 
-        },
-        _ => spinwave_single_q(q, &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, 0.),
+            })
+            .collect()
+    } else {
+        q_vectors
+            .into_par_iter()
+            .progress_count(n_q)
+            .map(|q| {
+                spinwave_single_q(
+                    Col::from_iter(q),
+                    &QIndependentComponents,
+                    n_sites,
+                    &couplings,
+                    &positions,
+                    rlu_to_cart,
+                    &rotating_components,
+                    save_Sab,
+                    0.,
+                )
+            })
+            .collect()
     }
 }
 
@@ -391,6 +390,9 @@ fn spinwave_triq(
 /// - `n_sites`: The number of sites in the system.
 /// - `couplings`: Slice of couplings between sites.
 /// - `positions`: The relative positions of each site within the unit cell.
+/// - `rotating_components`: Option with fields needed for rotating frame calculation.
+/// - `save_sab`: Whether to save the 3x3 Sab tensors or not.
+/// - `tri_id`: For optional rotating frame calculation, whether this is -k, 0 or +k
 ///
 ///# Returns
 /// A tuple containing:

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -1,7 +1,7 @@
 use std::f64::consts::PI;
 
 use faer::linalg::triangular_solve::solve_upper_triangular_in_place;
-use faer::{unzip, zip, Col, ColRef, Mat, MatRef, Par, Side, perm};
+use faer::{unzip, zip, Col, ColRef, Mat, MatRef, Par, Side, perm, mat};
 use faer::mat::{AsMatRef, AsMatMut};
 use indicatif::ParallelProgressIterator;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -13,6 +13,7 @@ use crate::{Coupling, MagneticField, C64};
 /// Minimum energy that isn't just set for zero (in meV)
 const ZERO_ENERGY_TOL: f64 = 1e-12;
 const J2PI: C64 = C64::new(0., 2. * PI);
+const C0: C64 = C64::new(0., 0.);
 
 /// The result of a single-Q spinwave calculation.
 ///
@@ -37,6 +38,19 @@ struct QIndependentComponents {
     z: Vec<Col<C64>>,
     spin_coefficients: Mat<C64>,
     Az: Option<Vec<C64>>,
+}
+
+/// Components required for the rotating frame calculations (Toth & Lake eq 39)
+/// Fields:
+/// - `km`: The propagation vector
+/// - `nx`: The cross-product matrix of the perpendicular vector in Rodrigues' formula
+/// - `R1`: The rotation matrix for the +/-km components
+/// - `R2`: The rotation matrix for the k=0 component
+struct RotatingFrameComponents {
+    km: Col<f64>,
+    nx: Mat<C64>,
+    R1: Mat<C64>,
+    R2: Mat<C64>,
 }
 
 /// Calculate the q-independent components of the calculation.
@@ -279,14 +293,43 @@ pub fn calc_spinwave(
     rotations: Vec<MatRef<C64>>,
     magnitudes: Vec<f64>,
     q_vectors: Vec<Vec<f64>>,
-    couplings: Vec<&Coupling>,
+    in_couplings: Vec<&Coupling>,
     positions: Vec<ColRef<f64>>,
     rlu_to_cart: Option<MatRef<f64>>,
     field: Option<MagneticField>,
+    rotating_frame: Option<Vec<ColRef<f64>>>,
     save_Sab: bool,
 ) -> Vec<SpinwaveResult> {
     let n_sites = rotations.len();
     let n_q = q_vectors.len() as u64;
+
+    let mut couplings = in_couplings;
+    // Need a second vector with mutable elements from which we can borrow due to Pyo3 limits.
+    let new_couplings: Vec<Coupling>;
+    let rotating_components: Option<RotatingFrameComponents> = match rotating_frame {
+        Some(rot_comps) => {
+            let km: Col<f64> = rot_comps[0].to_owned();
+            let n = Col::<C64>::from_iter(rot_comps[1].iter().map(|f| C64::new(*f, 0.)));
+            // Computes the rotation matrices in Toth & Lake eq 39
+            let nx = mat![[C0, -n[2] * J, n[1] * J], [n[2] * J, C0, -n[0] * J], [-n[1] * J, n[0] * J, C0]];
+            let R2 = n.clone().as_mat() * n.as_mat().transpose();
+            let R1 = (Mat::<C64>::identity(3, 3) - nx.as_ref() - R2.as_ref()) / 2.;
+            new_couplings = Vec::from_iter(couplings.iter().map(|c| {
+                let phi = 2. * PI * km.transpose() * c.inter_site_vector.as_ref();
+                // R is the Rodrigues rotation matrix
+                let R = Mat::<C64>::identity(3, 3) * phi.cos() + &nx * phi.sin() + (1. - phi.cos()) * &R2;
+                Coupling {
+                    index1: c.index1,
+                    index2: c.index2,
+                    matrix: (c.matrix.as_ref() * R.as_ref() + R.as_ref() * c.matrix.as_ref()) / 2.,
+                    inter_site_vector: c.inter_site_vector.clone(),
+                }
+            }));
+            couplings = Vec::from_iter(new_couplings.iter().map(|f| f));
+            Some(RotatingFrameComponents { km: km, nx: nx, R1: R1, R2: R2 })
+        },
+        _ => None,
+    };
 
     let QIndependentComponents = calc_q_independent(rotations, magnitudes, &couplings, field);
 
@@ -294,17 +337,51 @@ pub fn calc_spinwave(
         .into_par_iter()
         .progress_count(n_q)
         .map(|q| {
-            spinwave_single_q(
+            spinwave_triq(
                 Col::from_iter(q),
                 &QIndependentComponents,
                 n_sites,
                 &couplings,
                 &positions,
                 rlu_to_cart,
+                &rotating_components,
                 save_Sab,
             )
         })
         .collect()
+}
+
+/// Caculate energies and intensities for a triplet of q-vectors (rotating frame)
+/// For non-rotating frame calculations, just calls spinwave_single_q
+fn spinwave_triq(
+    q: Col<f64>,
+    q_indep: &QIndependentComponents,
+    n_sites: usize,
+    couplings: &[&Coupling],
+    pos: &[ColRef<f64>],
+    rlu_to_cart: Option<MatRef<f64>>,
+    rot: &Option<RotatingFrameComponents>,
+    save_Sab: bool,
+) -> SpinwaveResult {
+    match rot {
+        Some(..) => {
+            let Sm = spinwave_single_q(q.clone(), &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, -1.);
+            let S0 = spinwave_single_q(q.clone(), &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, 0.);
+            let Sp = spinwave_single_q(q.clone(), &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, 1.);
+            let sab: Option<Vec<Mat<C64>>> = match save_Sab {
+                true => {
+                    Some(vec![Sm.sab.unwrap(), S0.sab.unwrap(), Sp.sab.unwrap()].concat())
+                },
+                false => None,
+            };
+            SpinwaveResult {
+                energies: vec![Sm.energies, S0.energies, Sp.energies].concat(),
+                sab: sab,
+                intensities: vec![Sm.intensities, S0.intensities, Sp.intensities].concat(),
+            }
+        },
+        _ => spinwave_single_q(q, &q_indep, n_sites, &couplings, &pos, rlu_to_cart, &rot, save_Sab, 0.),
+    }
 }
 
 /// Calculate energies and intensities for a single q-vector.
@@ -321,16 +398,22 @@ pub fn calc_spinwave(
 /// - A vector containing the energies for the given q-vector.
 /// - A vector of S'^{alpha, beta} matrices for each eigenvalue at the given q-vector.
 fn spinwave_single_q(
-    q: Col<f64>,
+    mut q: Col<f64>,
     q_independent_components: &QIndependentComponents,
     n_sites: usize,
     couplings: &[&Coupling],
     positions: &[ColRef<f64>],
     rlu_to_cart: Option<MatRef<f64>>,
+    rotating_components: &Option<RotatingFrameComponents>,
     save_Sab: bool,
+    tri_id: f64,
 ) -> SpinwaveResult {
     let z = &q_independent_components.z;
     let spin_coefficients = &q_independent_components.spin_coefficients;
+
+    if let Some(rotcomp) = rotating_components {
+        q = q + tri_id * rotcomp.km.as_ref();
+    }
 
     let mut sqrt_hamiltonian =
         calc_sqrt_hamiltonian(q.clone(), q_independent_components, n_sites, couplings);
@@ -443,7 +526,7 @@ fn spinwave_single_q(
     });
 
     // now create S' for each eigenvalue (the only places where there are non-zero intensities)
-    let Sab: Vec<Mat<C64>> = (0..2 * n_sites)
+    let mut Sab: Vec<Mat<C64>> = (0..2 * n_sites)
         .map(|i| {
             // each element of S' over alpha, beta is created from an index over 2 * n_sites
             Mat::<C64>::from_fn(3, 3, |alpha, beta| -> C64 {
@@ -451,6 +534,24 @@ fn spinwave_single_q(
             })
         })
         .collect();
+
+    // For rotating frame calculation, apply rotation transformations to Sab
+    if let Some(rotcomp) = rotating_components {
+        // Convert back into lab frame (eq 37)
+        let R2I = &rotcomp.R2 - Mat::<C64>::identity(3, 3);
+        let R22I = (2. * &rotcomp.R2) - Mat::<C64>::identity(3, 3);
+        Sab.iter_mut().for_each(|m| *m = 0.5 * (&*m - (&rotcomp.nx * &*m * &rotcomp.nx)
+                                                    + (&R2I * &*m * &rotcomp.R2)
+                                                    + (&rotcomp.R2 * &*m * &R22I)));
+        // Apply the rotation transformation (eq 40)
+        match tri_id {
+            n if n < 0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R1.conjugate()),
+            n if n == 0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R2),
+            _ => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R1),
+        }
+        // Convert q back for qperp calculation
+        q = q - tri_id * rotcomp.km.as_ref();
+    }
 
     // gets the conversion from r.l.u. to Cartesian, for Sperp we need Q in Cartesians
     let qcart: Col<f64> = match rlu_to_cart {

--- a/src/spinwave.rs
+++ b/src/spinwave.rs
@@ -311,9 +311,10 @@ pub fn calc_spinwave(
             let km: Col<f64> = rot_comps[0].to_owned();
             let n = Col::<C64>::from_iter(rot_comps[1].iter().map(|f| C64::new(*f, 0.)));
             // Computes the rotation matrices in Toth & Lake eq 39
-            let nx = mat![[C0, -n[2] * J, n[1] * J], [n[2] * J, C0, -n[0] * J], [-n[1] * J, n[0] * J, C0]];
+            let iNx = mat![[C0, -n[2] * J, n[1] * J], [n[2] * J, C0, -n[0] * J], [-n[1] * J, n[0] * J, C0]];
+            let nx = mat![[C0, -n[2], n[1]], [n[2], C0, -n[0]], [-n[1], n[0], C0]];
             let R2 = n.clone().as_mat() * n.as_mat().transpose();
-            let R1 = (Mat::<C64>::identity(3, 3) - nx.as_ref() - R2.as_ref()) / 2.;
+            let R1 = (Mat::<C64>::identity(3, 3) - iNx.as_ref() - R2.as_ref()) / 2.;
             new_couplings = Vec::from_iter(couplings.iter().map(|c| {
                 let phi = 2. * PI * km.transpose() * c.inter_site_vector.as_ref();
                 // R is the Rodrigues rotation matrix
@@ -546,8 +547,9 @@ fn spinwave_single_q(
         // Apply the rotation transformation (eq 40)
         match tri_id {
             n if n < 0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R1.conjugate()),
+            n if n > 0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R1),
             n if n == 0. => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R2),
-            _ => Sab.iter_mut().for_each(|m| *m = &*m * &rotcomp.R1),
+            _ => panic!(),
         }
         // Convert q back for qperp calculation
         q = q - tri_id * rotcomp.km.as_ref();

--- a/tests/test_calc_impls.py
+++ b/tests/test_calc_impls.py
@@ -28,6 +28,7 @@ from examples.raw_calculations.antiferro_ef import antiferro_ef
 from examples.raw_calculations.kagome import kagome_ferromagnet
 from examples.raw_calculations.kagome_antiferro import kagome_antiferromagnet
 from examples.raw_calculations.kagome_supercell import kagome_supercell
+from examples.raw_calculations.triangular_antiferro import triangular_antiferro
 
 @pytest.mark.rust
 @pytest.mark.parametrize("example",
@@ -37,6 +38,7 @@ from examples.raw_calculations.kagome_supercell import kagome_supercell
                           antiferro_ef,
                           kagome_ferromagnet,
                           kagome_antiferromagnet,
+                          triangular_antiferro,
 #                          kagome_supercell,
                           ])
 def test_calc_impls(example):


### PR DESCRIPTION
Add a rotating frame (aka "incommensurate") calculation mode in both Python and Rust.

Also, created a new `RotationSupercell` to specifically address helical structures, because the $`S(\mathbf{Q},\omega)`$ calculation requires a rotation axis direction which is not otherwise stored anywhere (it's now a property of `RotationSupercell`. This also enables changing the `LatticeSite` moment property back to being real.

Fix #119 