### PR TITLE
Two quick fix of import

### DIFF
--- a/pyspinw/experiment.py
+++ b/pyspinw/experiment.py
@@ -8,7 +8,7 @@ from pyspinw.data import Data
 
 import numpy as np
 
-from instrument import Instrument
+from pyspinw.instrument import Instrument
 from pyspinw.serialisation import SPWSerialisable, SPWSerialisationContext, SPWDeserialisationContext
 
 

--- a/pyspinw/measurement.py
+++ b/pyspinw/measurement.py
@@ -1,5 +1,7 @@
 """ Description of measurements """
 
+from pathlib import Path
+
 class Measurement:
     """ Provides the q and E parameters specific to a given measurement """
 

--- a/pyspinw/measurement.py
+++ b/pyspinw/measurement.py
@@ -1,6 +1,6 @@
 """ Description of measurements """
 
-from pathlib import Path
+from pyspinw.path import Path
 
 class Measurement:
     """ Provides the q and E parameters specific to a given measurement """


### PR DESCRIPTION
  The following two minor changes are to remove warnings while auto-generating sphinx docs.

* Changed the import of `Instrument` in `pyspinw/experiment.py` to use an explicit module path.
* Added a missing import for `Path` from ~`pathlib`~  `pyspinw/path.py` in `pyspinw/measurement.py`.