### PR TITLE
Fix actions test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,3 @@ jobs:
         # `--runxfail` means 'expect xfail tests to pass' - the Rust tests
         # are set to xfail if the Rust module is not available
         python -m pytest --runxfail -m rust 
-    - name: Setup tmate
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.12"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +27,7 @@ jobs:
     - name: Set up python paths (POSIX)
       run: |
         export PYTHONPATH=pyspinw
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15'
     - name: Set up python paths (Windows)
       run: |
         set PYTHONPATH=pyspinw
@@ -43,7 +43,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-test.txt
     - name: Run tests with pyTest (non-Linux)
-      if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
+      if: matrix.os == 'windows-latest' || matrix.os == 'macos-15'
       run: |
         python -m pytest
     - name: Run tests with pyTest and coverage (Linux)
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.12"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Install GL Dependencies (Linux)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.12"]
-        os: [ubuntu-latest, macos-15, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +27,7 @@ jobs:
     - name: Set up python paths (POSIX)
       run: |
         export PYTHONPATH=pyspinw
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15'
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
     - name: Set up python paths (Windows)
       run: |
         set PYTHONPATH=pyspinw
@@ -43,7 +43,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-test.txt
     - name: Run tests with pyTest (non-Linux)
-      if: matrix.os == 'windows-latest' || matrix.os == 'macos-15'
+      if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
       run: |
         python -m pytest
     - name: Run tests with pyTest and coverage (Linux)
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.12"]
-        os: [ubuntu-latest, macos-15, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Install GL Dependencies (Linux)
@@ -95,3 +95,6 @@ jobs:
         # `--runxfail` means 'expect xfail tests to pass' - the Rust tests
         # are set to xfail if the Rust module is not available
         python -m pytest --runxfail -m rust 
+    - name: Setup tmate
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3

--- a/tests/test_calc_impls.py
+++ b/tests/test_calc_impls.py
@@ -55,4 +55,4 @@ def test_calc_impls(example):
     np.testing.assert_allclose(np.sort(rs_energies), np.sort(py_energies), atol=1e-6, rtol=0)
     # remove very large values of intensity
     rs_sqw, py_sqw = (np.array(sqw)[np.where(np.array(sqw) < 100)] for sqw in [rs_sqw, py_sqw])
-    np.testing.assert_allclose(np.sort(rs_sqw), np.sort(py_sqw), atol=1e-6, rtol=1e-3)
+    np.testing.assert_allclose(np.sort(rs_sqw), np.sort(py_sqw), atol=1e-6, rtol=1.5e-3)


### PR DESCRIPTION
Recently github upgraded their `macos-latest` runners to use MacOS-26 ("Tahoe") instead of MacOS-15 and this caused a failure in our rust vs Python comparison test.

Specifically, the failrue is only in a single rust vs python test for `square_antiferro_nonherm` (comparing the values calculated by Rust and by Python) in a single Q-point where the rust code gives intensities of `9.5411e-02`, `9.5442e-02` and `9.5513e-02` and the Python code gives `9.5296e-02`, `9.5385e-02`, `9.5392e-02`, which respectively are absolute differences of `1.1527e-04`, `5.7126e-05`, and `1.2142e-04` and relative differences of `1.2082e-03`, `5.9854e-04` and `1.2712e-03`. So there are two failures on both absolute and relative tolerances - there is another failure on absolute tolerance but within a relative tolerance of `5e-5`. These are small errors which are probably due to the system being non-hermitian and the back-end BLAS library in MacOS changing between Sequoia and Tahoe.

We can make the tests pass if we increase the relative tolerance slightly to `1.3e-3` from `1e-3` which is what this PR does (relaxing it slightly more to `1.5e-3`.)