### PR TITLE
Real world powder fit

### DIFF
--- a/examples/tutorials/bimn2o5_fitting.py
+++ b/examples/tutorials/bimn2o5_fitting.py
@@ -1,0 +1,103 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+from scipy.io import loadmat
+from scipy.optimize import least_squares, Bounds
+from pyspinw import *
+
+""" Set up model for BiMn2O5 for powder fitting """
+cif_struc = load_cif(os.path.join(os.path.dirname(__file__), 'data_files', 'ICSD_CollCode117638.cif'))
+# Magnetic structure from PRB77 134434 Table IV
+S0 = np.array([[2.10, -0.33,  0.25j], [ 2.10, -0.33, -0.25j], [ 2.07,  0.56,  0.08j], [ 2.07,  0.56, -0.08j],
+               [-2.83, -0.23,  0.00], [-2.83,  0.33,  0.00], [ 2.80, -0.34,  0.00], [-2.74, -0.64,  0.00]])
+# Note that CIF has no magnetic moment information and PySpinW objects are *immutable*
+# So we have to set the magnetic moments in a copy of the sites list and create a new structure
+sites = cif_struc.sites_by_name('Mn1') + cif_struc.sites_by_name('Mn2')
+perm, scales = [3, 2, 0, 1, 7, 4, 5, 6], [1.5]*4 + [2]*4
+for mom, idx, scale in zip(S0, perm, scales):
+    sites[idx].spin = mom / np.linalg.norm(np.real(mom)) * scale
+structure = Structure(sites, unit_cell=cif_struc.unit_cell, spacegroup=cif_struc.spacegroup,
+                      supercell=SummationSupercell([CommensuratePropagationVector(0.5, 0, 0.5)]))
+
+# Set the exchange interactions Jx, Kx using notation of PRB84 054444
+# J1 and J2 along c, J3 (inter-chain), J4 (intra Mn3-Mn4), J5 (intra Mn3-Mn3)
+Jvec = [-0.31, 0.45, 0.2, 3.544, 1.07, 0.59, 2.85]  # J1-J5, K1, K2
+exchanges = generate_exchanges(structure, bond=1, j=Jvec[0], naming_pattern='J1') \
+          + generate_exchanges(structure, bond=3, j=Jvec[1], naming_pattern='J2') \
+          + generate_exchanges(structure, bond=4, j=Jvec[2], color=[1,0,0], naming_pattern='J3') \
+          + generate_exchanges(structure, bond=5, j=Jvec[3], color=[0,1,0], naming_pattern='J4') \
+          + generate_exchanges(structure, bond=2, j=Jvec[4], color=[0,0,1], naming_pattern='J5')
+
+anisotropies = axis_anisotropies(sites[:4], a=Jvec[5], name="K1") \
+             + axis_anisotropies(sites[4:], a=Jvec[6], name="K2")
+
+hamiltonian = Hamiltonian(structure, exchanges, anisotropies)
+hamiltonian.print_summary()
+view(hamiltonian)
+
+# Try to optimise the structure (currently buggy)
+#optstruc = hamiltonian.ground_state(initial_randomisation='randomised', planar=hamiltonian.structure.sites)
+#view(optstruc)
+#optstruc.print_summary()
+
+# Compute a "spaghetti plot"
+path = Path([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]])
+hamiltonian.spaghetti_plot(path)
+
+# Compute the powder spectrum
+sample = Powder(hamiltonian)
+path = Path1D(0.01, 4, n_points=101)
+fig = sample.show_spectrum(path, n_energy_bins=100, n_samples=500, energy_stddev=0.4,
+                           ignore_imaginary=True, show=False)
+fig.axes[0].collections[0].set_clim(0, 5)
+cb = plt.colorbar(fig.axes[0].collections[0])
+plt.show()
+
+# Loads experimental data
+mat = loadmat(os.path.join(os.path.dirname(__file__), 'data_files', 'bimn2o5_ei30.mat'))
+en, qm, dat, err = (np.squeeze(v) for v in [mat['x'][0][0], mat['x'][0][1], mat['y'], mat['e']])
+path = Path1D(np.min(qm), np.max(qm), n_points=len(qm))
+
+# Set up a fitting function - the parameters take the form of "<Name.ParameterName>"
+# Where "Name" is the name used in their creation (e.g. J1, K1 etc above)
+# and "ParameterName" is the name of the variable used in the constructor (e.g. "j" or "a")
+# Note the use of n_samples=50 here to reduce running time (to ~10min)
+specfunc = sample.parameterized_spectrum(parameters=["J1.j", "J2.j", "J4.j", "J5.j", "K1.a", "K2.a"],
+                                         path=path, n_energy_bins=len(en), n_samples=50,
+                                         min_energy=np.min(en), max_energy=np.max(en),
+                                         energy_stddev=0.4, ignore_imaginary=True)
+# Test that evaluating the fit function works
+spectrum = specfunc(-0.31, 0.45, 3.544, 1.07, 0.59, 2.85)
+spectrum[np.where(np.isnan(dat))] = np.nan
+# Plot the spectrum over the data
+fig, ax = plt.subplots()
+mesh = ax.pcolormesh(qm, en, dat.T, shading='nearest', vmin=0, vmax=5)
+Xi, Yi = np.meshgrid(qm, en)
+ax.contour(Xi, Yi, spectrum.T, levels=np.linspace(0, 5, 10), linewidths=1.0, colors='k')
+cb = fig.colorbar(mesh, ax=ax)
+plt.show()
+
+# Define mimization function which automatically fits a scale factor
+nnan = np.where(~np.isnan(dat))
+def minfun(x):
+    calc = specfunc(*tuple(x))
+    def scalefun(y):
+        return (dat[nnan] - y*calc[nnan]).reshape(-1)
+    y_opt = least_squares(scalefun, x0=100., bounds=Bounds([0.0], [1e9]), diff_step=1e-2)
+    return (dat[nnan] - y_opt.x*calc[nnan]).reshape(-1)
+
+def callback(intermediate_result):
+    """Callback to print out what is going on"""
+    print(intermediate_result)
+
+fitpars = least_squares(minfun, x0=[-0.31, 0.45, 3.544, 1.07, 0.59, 2.85], callback=callback, diff_step=1e-2)
+print(fitpars)
+
+# Plot fitted spectrum
+spectrum = specfunc(*tuple(fitpars.x))
+fig, ax = plt.subplots()
+mesh = ax.pcolormesh(qm, en, dat.T, shading='nearest', vmin=0, vmax=5)
+Xi, Yi = np.meshgrid(qm, en)
+ax.contour(Xi, Yi, spectrum.T, levels=np.linspace(0, 5, 10), linewidths=1.0, colors='k')
+cb = fig.colorbar(mesh, ax=ax)
+plt.show()

--- a/pyspinw/anisotropy.py
+++ b/pyspinw/anisotropy.py
@@ -34,6 +34,8 @@ class Anisotropy(SPWSerialisable):
         Lattice site to which the anisotropy term applies.
     anisotropy_matrix
         3x3 matrix defining the anisotropy contribution for the site.
+    name
+        Optional name
     """
 
     #: Type name used when serialising anisotropy terms to SPW data.
@@ -43,10 +45,11 @@ class Anisotropy(SPWSerialisable):
     scalar_parameters = []
 
     @check_sizes(anisotropy_matrix=(3, 3), force_numpy=True)
-    def __init__(self, site: LatticeSite, anisotropy_matrix: ArrayLike):
+    def __init__(self, site: LatticeSite, anisotropy_matrix: ArrayLike, name: str = ""):
         self._site = site
         self._anisotropy_matrix = np.array(anisotropy_matrix)
         self._unique_id = _generate_unique_anisotropy_id()
+        self._name = name
 
     @property
     def unique_id(self):
@@ -67,13 +70,15 @@ class Anisotropy(SPWSerialisable):
             return self._anisotropy_matrix
 
     def _serialise(self, context: SPWSerialisationContext) -> dict:
-        return {"site": self._site._serialise(context), "anisotropy_matrix": numpy_serialise(self._anisotropy_matrix)}
+        return {"site": self._site._serialise(context),
+                "anisotropy_matrix": numpy_serialise(self._anisotropy_matrix),
+                "name": self._name}
 
     @staticmethod
     def _deserialise(json: dict, context: SPWDeserialisationContext):
         site = LatticeSite._deserialise(json["site"], context)
         anisotropy_matrix = numpy_deserialise(json["anisotropy_matrix"])
-        return Anisotropy(site, anisotropy_matrix)
+        return Anisotropy(site, anisotropy_matrix, json["name"])
 
     @property
     def parameter_string(self):
@@ -81,10 +86,15 @@ class Anisotropy(SPWSerialisable):
         m = self.anisotropy_matrix.reshape(-1)
         return f"[[{m[0]}, {m[1]}, {m[2]}], [{m[3]}, {m[4]}, {m[5]}], [{m[6]}, {m[7]}, {m[8]}]]"
 
-    def __repr__(self):
-        return f"Anisotropy({self.site.name}, {self.parameter_string})"
+    @property
+    def name(self):
+        """Name of this anisotropy"""
+        return self._name
 
-    def updated(self, site: LatticeSite | None = None, anisotropy_matrix: ArrayLike | None = None):
+    def __repr__(self):
+        return f"{self.__class__.__name__}('{self.name}', {self.site.name}, {self.parameter_string})"
+
+    def updated(self, site: LatticeSite | None = None, anisotropy_matrix: ArrayLike | None = None, name: str = ""):
         """Return a copy of this anisotropy term with variables replaced.
 
         Parameters
@@ -93,10 +103,13 @@ class Anisotropy(SPWSerialisable):
             Replacement lattice site. If omitted, the current site is reused.
         anisotropy_matrix
             Replacement anisotropy matrix. If omitted, the current matrix is reused.
+        name
+            Optional name. If omitted, current name is reused.
         """
         return Anisotropy(
             site=self.site if site is None else site,
             anisotropy_matrix=self.anisotropy_matrix if anisotropy_matrix is None else np.array(anisotropy_matrix),
+            name=self.name if name is None else name,
         )
 
 
@@ -111,13 +124,19 @@ class AxisMagnitudeAnisotropy(Anisotropy):
         Anisotropy constant.
     direction
         Principal anisotropy direction. The vector is normalized before use.
+    name
+        Optional name.
     """
 
     #: Names of scalar fields that can be varied by parameter definitions.
     scalar_parameters = ["a"]
 
     @check_sizes(direction=(3,), force_numpy=True)
-    def __init__(self, site: LatticeSite, a: float, direction: ArrayLike = np.array([0, 0, 1])):
+    def __init__(self,
+                 site: LatticeSite,
+                 a: float,
+                 direction: ArrayLike = np.array([0, 0, 1]),
+                 name: str = ""):
         direction = np.array(direction)
         mag = np.sqrt(np.sum(direction**2))
 
@@ -128,7 +147,7 @@ class AxisMagnitudeAnisotropy(Anisotropy):
 
         anisotropy_matrix = a * direction.reshape(3, 1) * direction.reshape(1, 3)
 
-        super().__init__(site, anisotropy_matrix)
+        super().__init__(site, anisotropy_matrix, name)
         self._a = a
 
     @property
@@ -151,14 +170,12 @@ class AxisMagnitudeAnisotropy(Anisotropy):
         """A string representation of the parameters."""
         return f"a={self.constant}, axis={self.direction}"
 
-    def __repr__(self):
-        return f"Anisotropy({self.site.name}, {self.parameter_string})"
-
     def _serialise(self, context: SPWSerialisationContext):
         return {
             "site": self._site._serialise(context),
             "direction": numpy_serialise(self._direction),
             "a": float(self._a),
+            "name": self._name,
         }
 
     @staticmethod
@@ -167,9 +184,13 @@ class AxisMagnitudeAnisotropy(Anisotropy):
             LatticeSite._deserialise(json["site"], context),
             json["a"],
             numpy_deserialise(json["direction"]),
+            json["name"],
         )
 
-    def updated(self, site: LatticeSite | None = None, a: float | None = None, direction: ArrayLike | None = None):
+    def updated(self, site: LatticeSite | None = None,
+                a: float | None = None,
+                direction: ArrayLike | None = None,
+                name: str | None = None):
         """Return a copy of this anisotropy term with variables replaced.
 
         Parameters
@@ -180,9 +201,12 @@ class AxisMagnitudeAnisotropy(Anisotropy):
             Replacement anisotropy constant. If omitted, the current constant is reused.
         direction
             Replacement principal anisotropy direction. If omitted, the current direction is reused.
+        name
+            Optional name. If omitted, current name is reused.
         """
         return AxisMagnitudeAnisotropy(
             site=self.site if site is None else site,
             a=self.a if a is None else a,
             direction=self.direction if direction is None else np.array(direction),
+            name=self.name if name is None else name,
         )

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -166,7 +166,7 @@ def _regularise_parameters(hamiltonian: "Hamiltonian", parameter_data: Parametri
     for target, parameter in parameter_data:
         if isinstance(target, str):
 
-            exchanges = hamiltonian.exchanges_by_name(target)
+            exchanges = hamiltonian.exchanges_by_name(target) + hamiltonian.anisotropies_by_name(target)
 
             if len(exchanges) == 0:
                 raise ValueError(f"Could not find exchanges that match {target}")
@@ -238,11 +238,14 @@ class Hamiltonian(SPWSerialisable):
         """ Get list of exchanges whose names match the regex """
         return [exchange for exchange in self.exchanges if re.match(regex, exchange.name) is not None]
 
-
     @property
     def anisotropies(self):
         """ Get the anisotropies """
         return self._anisotropies
+
+    def anisotropies_by_name(self, regex):
+        """ Get list of anisotropies whose names match the regex """
+        return [anisotropy for anisotropy in self.anisotropies if re.match(regex, anisotropy.name) is not None]
 
     @property
     def text_summary(self) -> str:

--- a/pyspinw/interface.py
+++ b/pyspinw/interface.py
@@ -469,6 +469,10 @@ def generate_exchanges(sites: list[LatticeSite] | Structure,
         else:
             used_parameters[parameter] = default
 
+    # Adds extra parameters
+    if color is not None:
+        used_parameters['color'] = color
+
     group = ExchangeGroup(
         name = "<unnamed group>",
         bond = bond,

--- a/pyspinw/interface.py
+++ b/pyspinw/interface.py
@@ -491,21 +491,23 @@ def generate_exchanges(sites: list[LatticeSite] | Structure,
 def axis_anisotropies(
         sites: list[LatticeSite] | Structure,
         a: float,
-        axis: ArrayLike = [0, 0, 1]):
+        axis: ArrayLike = [0, 0, 1],
+        name: str = ""):
     """ Create anisotropy objects with magnitude `a` in direction `axis` for each site """
     if isinstance(sites, Structure):
         sites = sites.sites
-    return [AxisMagnitudeAnisotropy(site, a, axis) for site in sites]
+    return [AxisMagnitudeAnisotropy(site, a, axis, name) for site in sites]
 
 
 @check_sizes(matrix=(3,3), force_numpy=True)
 def matrix_anisotropies(
         sites: list[LatticeSite] | Structure,
-        matrix: ArrayLike):
+        matrix: ArrayLike,
+        name: str = ""):
     """ Create anisotropy objects specified by a matrix, the same for each site """
     if isinstance(sites, Structure):
         sites = sites.sites
-    return [Anisotropy(site, matrix) for site in sites]
+    return [Anisotropy(site, matrix, name) for site in sites]
 
 def view(hamiltonian: Hamiltonian):
     """ Show the current Hamiltonian in the viewer"""

--- a/pyspinw/sample.py
+++ b/pyspinw/sample.py
@@ -517,7 +517,7 @@ class Powder(Sample1D):
                     binned += (intensity_value * normalisation_factor) * gaussian
 
 
-            output[i, :] = binned
+            output[i, :] = binned / chunk_size
 
         return path.q_values(), energy_bin_centres, output
 
@@ -574,8 +574,7 @@ class Powder(Sample1D):
                                        min_energy, max_energy, n_energy_bins, energy_stddev,
                                        random_seed, use_rust, ignore_imaginary)
         else:
-            n_energy_bins = n_samples // 4 if n_energy_bins is None else n_energy_bins
-            q, e = path.q_values(), np.linspace(min_energy, max_energy, n_energy_bins + 1)
+            q, e = path.q_values(), np.linspace(min_energy, max_energy, data.shape[1])
 
         if isinstance(scaling_method, str):
             scaling_method = ScalingMethod(scaling_method)
@@ -596,7 +595,7 @@ class Powder(Sample1D):
         else:
             fig, ax = plt.gcf(), plt.gca()
 
-        ax.imshow(data.T[::-1, :], extent=(q[0], q[-1], e[0], e[-1]))
+        ax.pcolormesh(q, e, data.T, shading='nearest')
         ax.set_xlabel(r"$|q| (\AA^{-1})$")
         ax.set_ylabel("Energy (meV)")
         ax.set_aspect(0.2)

--- a/pyspinw/sample.py
+++ b/pyspinw/sample.py
@@ -406,9 +406,6 @@ class ParameterizedPowderSpectrum:
                  find_ground_state_with: dict | None=None,
                  ignore_imaginary: bool = False):
 
-        self._powder = Powder
-        self._parameters = parameters
-
         self._path = path
         self._n_samples = n_samples
         self._method = method

--- a/pyspinw/sample.py
+++ b/pyspinw/sample.py
@@ -470,7 +470,7 @@ class Powder(Sample1D):
 
         intensities = np.real(np.array(intensities))
         if ignore_imaginary:
-            i_imag = np.where(np.abs(np.imag(energies)) > tolerances.IMAG_MODE_TOL)[0]
+            i_imag = np.where(np.abs(np.imag(energies)) > tolerances.IMAG_MODE_TOL)
             intensities[i_imag] = 0
         energies = np.real(np.array(energies))
 
@@ -551,7 +551,7 @@ class Powder(Sample1D):
                         ignore_imaginary=ignore_imaginary)
 
     def show_spectrum(self,
-                      path: Path1D | EmpiricalPath1D | ArrayLike,
+                      path: Path1D | EmpiricalPath1D | ArrayLike | tuple,
                       n_samples: int = 100,
                       method: SphericalPointGeneratorType | str = "fibonacci",
                       min_energy: float | None = None,
@@ -563,14 +563,19 @@ class Powder(Sample1D):
                       show: bool = True,
                       new_figure: bool = True,
                       use_rust: bool = True,
+                      data: ArrayLike | None = None,
                       ignore_imaginary: bool = False):
         """ Show the powder spectrum """
         if not isinstance(path, Path1DBase):
             path = EmpiricalPath1D(path)
 
-        q, e, data = self.spectrum(path, n_samples, method,
-                                   min_energy, max_energy, n_energy_bins, energy_stddev,
-                                   random_seed, use_rust, ignore_imaginary)
+        if data is None or min_energy is None or max_energy is None:
+            q, e, data = self.spectrum(path, n_samples, method,
+                                       min_energy, max_energy, n_energy_bins, energy_stddev,
+                                       random_seed, use_rust, ignore_imaginary)
+        else:
+            n_energy_bins = n_samples // 4 if n_energy_bins is None else n_energy_bins
+            q, e = path.q_values(), np.linspace(min_energy, max_energy, n_energy_bins + 1)
 
         if isinstance(scaling_method, str):
             scaling_method = ScalingMethod(scaling_method)

--- a/pyspinw/sample.py
+++ b/pyspinw/sample.py
@@ -591,7 +591,10 @@ class Powder(Sample1D):
         import matplotlib.pyplot as plt
 
         if new_figure:
-            fig, ax = plt.subplots(num="Powder Spectrum")
+            if plt.fignum_exists("Powder Spectrum"):
+                fig, ax = plt.subplots()
+            else:
+                fig, ax = plt.subplots(num="Powder Spectrum")
         else:
             fig, ax = plt.gcf(), plt.gca()
 

--- a/pyspinw/sample.py
+++ b/pyspinw/sample.py
@@ -403,7 +403,8 @@ class ParameterizedPowderSpectrum:
                  energy_stddev: float | None = None,
                  random_seed: int | None = None,
                  use_rust: bool = True,
-                 find_ground_state_with: dict | None=None):
+                 find_ground_state_with: dict | None=None,
+                 ignore_imaginary: bool = False):
 
         self._powder = Powder
         self._parameters = parameters
@@ -418,6 +419,7 @@ class ParameterizedPowderSpectrum:
         self._random_seed = random_seed
         self._use_rust = use_rust
         self._find_ground_state_with = find_ground_state_with
+        self._ignore_imaginary = ignore_imaginary
 
         self.parameterised_hamiltonian = powder.hamiltonian.parameterize(
                                 *parameters,
@@ -435,7 +437,8 @@ class ParameterizedPowderSpectrum:
             n_energy_bins=self._n_energy_bins,
             energy_stddev=self._energy_stddev,
             random_seed=self._random_seed,
-            use_rust=self._use_rust)[2]
+            use_rust=self._use_rust,
+            ignore_imaginary=self._ignore_imaginary)[2]
 
 
 class Powder(Sample1D):
@@ -454,7 +457,8 @@ class Powder(Sample1D):
                  n_energy_bins: int | None = None,
                  energy_stddev: float | None = None,
                  random_seed: int | None = None,
-                 use_rust: bool = True):
+                 use_rust: bool = True,
+                 ignore_imaginary: bool = False):
         """ Get the powder spectrum """
         if not isinstance(path, Path1DBase):
             path = EmpiricalPath1D(path)
@@ -467,8 +471,11 @@ class Powder(Sample1D):
 
         energies, intensities = self.hamiltonian._energies_and_intensities(points, use_rust=use_rust)
 
-        energies = np.real(np.array(energies))
         intensities = np.real(np.array(intensities))
+        if ignore_imaginary:
+            i_imag = np.where(np.abs(np.imag(energies)) > tolerances.IMAG_MODE_TOL)[0]
+            intensities[i_imag] = 0
+        energies = np.real(np.array(energies))
 
         positive_energies = energies > 0
 
@@ -528,7 +535,8 @@ class Powder(Sample1D):
             energy_stddev: float | None = None,
             random_seed: int | None = None,
             use_rust: bool = True,
-            find_ground_state_with: dict | None = None):
+            find_ground_state_with: dict | None = None,
+            ignore_imaginary: bool = False):
         """ Get the powder spectrum as a function of parameters """
         return ParameterizedPowderSpectrum(
                         self,
@@ -542,7 +550,8 @@ class Powder(Sample1D):
                         energy_stddev=energy_stddev,
                         random_seed=random_seed,
                         use_rust=use_rust,
-                        find_ground_state_with=find_ground_state_with)
+                        find_ground_state_with=find_ground_state_with,
+                        ignore_imaginary=ignore_imaginary)
 
     def show_spectrum(self,
                       path: Path1D | EmpiricalPath1D | ArrayLike,
@@ -556,14 +565,15 @@ class Powder(Sample1D):
                       scaling_method: ScalingMethod | str = 'linear',
                       show: bool = True,
                       new_figure: bool = True,
-                      use_rust: bool = True):
+                      use_rust: bool = True,
+                      ignore_imaginary: bool = False):
         """ Show the powder spectrum """
         if not isinstance(path, Path1DBase):
             path = EmpiricalPath1D(path)
 
         q, e, data = self.spectrum(path, n_samples, method,
                                    min_energy, max_energy, n_energy_bins, energy_stddev,
-                                   random_seed, use_rust)
+                                   random_seed, use_rust, ignore_imaginary)
 
         if isinstance(scaling_method, str):
             scaling_method = ScalingMethod(scaling_method)

--- a/pyspinw/sample.py
+++ b/pyspinw/sample.py
@@ -554,7 +554,7 @@ class Powder(Sample1D):
                       energy_stddev: float | None = None,
                       random_seed: int | None = None,
                       scaling_method: ScalingMethod | str = 'linear',
-                      show_plot: bool = True,
+                      show: bool = True,
                       new_figure: bool = True,
                       use_rust: bool = True):
         """ Show the powder spectrum """
@@ -580,17 +580,19 @@ class Powder(Sample1D):
         import matplotlib.pyplot as plt
 
         if new_figure:
-            plt.figure("Powder Spectrum")
+            fig, ax = plt.subplots(num="Powder Spectrum")
+        else:
+            fig, ax = plt.gcf(), plt.gca()
 
-        ax = plt.gca()
-
-        plt.imshow(data.T[::-1, :], extent=(q[0], q[-1], e[0], e[-1]))
-        plt.xlabel(r"$|q| (\AA^{-1})$")
-        plt.ylabel("Energy (meV)")
+        ax.imshow(data.T[::-1, :], extent=(q[0], q[-1], e[0], e[-1]))
+        ax.set_xlabel(r"$|q| (\AA^{-1})$")
+        ax.set_ylabel("Energy (meV)")
         ax.set_aspect(0.2)
 
-        if show_plot:
+        if show:
             plt.show()
+        else:
+            return fig
 
 
 

--- a/pyspinw/tolerances.py
+++ b/pyspinw/tolerances.py
@@ -13,5 +13,6 @@ class Tolerances:
     IS_INTEGER_TOL = 1e-6
     IS_ZERO_TOL = 1e-10
     BOND_TOL = 1e-6        # Distance tolerance to consider same bond
+    IMAG_MODE_TOL = 1e-2   # Value of imaginary energy (meV) below which to ignore
 
 tolerances = Tolerances()


### PR DESCRIPTION
Adds a new tutorial to run a powder fitting on a "real world" example of BiMn2O5.

Also fix some issues:

* Propagate through user `color` choice in exchanges definition
* Add names for `anisotropy` objects so they can be specified in `parameterized_spectrum`
* Add option to ignore imaginary modes when calculating powder spectra
* Change powder spectrum plotting to use `pcolormesh` to be more accurate w.r.t. axes
* Add option to return a figure from powder spectrum plot
* Add option to plot a precalculated data in powder spectrum plot
