### PR TITLE
161 make viewer work for rotationsupercell

### DIFF
--- a/debug/viewer_debug_incommensurate.py
+++ b/debug/viewer_debug_incommensurate.py
@@ -1,0 +1,30 @@
+from multiprocessing import freeze_support
+
+from pyspinw.exchange import HeisenbergExchange
+from pyspinw.gui.viewer import show_object
+from pyspinw.hamiltonian import Hamiltonian
+from pyspinw.site import LatticeSite
+from pyspinw.structures import Structure
+from pyspinw.symmetry.unitcell import UnitCell
+
+unit_cell = UnitCell(1,1,1, alpha=50, beta=60, gamma=70)
+
+origin = LatticeSite(0,0,0, name="origin")
+a = LatticeSite(0.5,0,0, name="a")
+b = LatticeSite(0,0.5,0, name="b")
+c = LatticeSite(0,0,0.5, name="c")
+
+sites = [origin, a, b, c]
+exchanges = [HeisenbergExchange(origin, a, j=0, name="a"),
+             HeisenbergExchange(origin, b, j=0, name="b"),
+             HeisenbergExchange(origin, c, j=0, name="c")]
+
+
+s = Structure(sites, unit_cell=unit_cell)
+
+hamiltonian = Hamiltonian(s, exchanges)
+
+hamiltonian.print_summary()
+
+
+show_object(hamiltonian, copies=(2,3,4))

--- a/debug/viewer_debug_incommensurate_but_not.py
+++ b/debug/viewer_debug_incommensurate_but_not.py
@@ -16,7 +16,7 @@ site = LatticeSite(0.5, 0.5, 0.5, 1, 0, 0, name="origin")
 
 supercell = RotationSupercell(
     np.array([0,1,0]),
-    np.array([0,0,np.sqrt(1/10)]))
+    np.array([0,0,1/3]))
 
 s = Structure([site], unit_cell=unit_cell, supercell=supercell)
 

--- a/debug/viewer_lattice_multiple_copies.py
+++ b/debug/viewer_lattice_multiple_copies.py
@@ -1,0 +1,30 @@
+from multiprocessing import freeze_support
+
+from pyspinw.exchange import HeisenbergExchange
+from pyspinw.gui.viewer import show_object
+from pyspinw.hamiltonian import Hamiltonian
+from pyspinw.site import LatticeSite
+from pyspinw.structures import Structure
+from pyspinw.symmetry.unitcell import UnitCell
+
+unit_cell = UnitCell(1,1,1, alpha=50, beta=60, gamma=70)
+
+origin = LatticeSite(0,0,0, name="origin")
+a = LatticeSite(0.5,0,0, name="a")
+b = LatticeSite(0,0.5,0, name="b")
+c = LatticeSite(0,0,0.5, name="c")
+
+sites = [origin, a, b, c]
+exchanges = [HeisenbergExchange(origin, a, j=0, name="a"),
+             HeisenbergExchange(origin, b, j=0, name="b"),
+             HeisenbergExchange(origin, c, j=0, name="c")]
+
+
+s = Structure(sites, unit_cell=unit_cell)
+
+hamiltonian = Hamiltonian(s, exchanges)
+
+hamiltonian.print_summary()
+
+
+show_object(hamiltonian, copies=(2,3,4))

--- a/pyspinw/cell_offsets.py
+++ b/pyspinw/cell_offsets.py
@@ -94,7 +94,6 @@ CellOffsetCoercible = CellOffset | tuple[int, int, int] | None
 
 def cell_offset_generator(a, b, c):
     """ Iterator for cells in supercell """
-
     for i in range(a):
         for j in range(b):
             for k in range(c):

--- a/pyspinw/cell_offsets.py
+++ b/pyspinw/cell_offsets.py
@@ -90,3 +90,12 @@ class CellOffset(SPWSerialisable):
         return CellOffset(-self.i, -self.j, -self.k)
 
 CellOffsetCoercible = CellOffset | tuple[int, int, int] | None
+
+
+def cell_offset_generator(a, b, c):
+    """ Iterator for cells in supercell """
+
+    for i in range(a):
+        for j in range(b):
+            for k in range(c):
+                yield CellOffset(i, j, k)

--- a/pyspinw/gui/crystalview.py
+++ b/pyspinw/gui/crystalview.py
@@ -363,7 +363,7 @@ class CrystalViewerWidget(QOpenGLWidget):
 
             self.cell_shader.camera = self.camera
 
-            for offset in self.render_model.hamiltonian.structure.supercell.cells():
+            for offset in self.render_model.cells():
                 translation_matrix = np.eye(4, dtype=np.float32)
                 translation_matrix[:3, 3] = offset.vector
 

--- a/pyspinw/gui/rendermodel.py
+++ b/pyspinw/gui/rendermodel.py
@@ -10,6 +10,7 @@ from pyspinw.gui.edge_cases import add_extra_edge_lines, add_extra_edge_points
 from pyspinw.gui.wrap_line import split_and_wrap_line_segment
 from pyspinw.hamiltonian import Hamiltonian
 from pyspinw.site import LatticeSite
+from pyspinw.symmetry.supercell import CommensurateSupercell
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.util import rotation_from_z
 
@@ -178,7 +179,21 @@ class RenderAnisotropy(Component):
 class RenderModel:
     """ Model of the hamiltonian, contains lots of derived information for rendering and text representation"""
 
-    def __init__(self, hamiltonian: Hamiltonian):
+    def __init__(self,
+                 hamiltonian: Hamiltonian,
+                 copies: tuple[int, int, int] = (1,1,1),
+                 rotation_supercell_expansion_max=(10,10,10)):
+
+
+        # Deal with added scaling, and rotation supercells
+        if isinstance(hamiltonian.structure.supercell, CommensurateSupercell):
+            # Change the scaling on the supercell
+            new_scaling = tuple(x*y for x, y in zip(copies, hamiltonian.structure.supercell.scaling))
+
+            hamiltonian = hamiltonian.updated(
+                structure = hamiltonian.structure.updated(
+                    supercell = hamiltonian.structure.supercell.rescale(new_scaling)
+                ))
 
         self.hamiltonian = hamiltonian
 

--- a/pyspinw/gui/rendermodel.py
+++ b/pyspinw/gui/rendermodel.py
@@ -1,16 +1,18 @@
 """ Representation of the Hamiltonian that has lots of precalculated stuff needed for rendering it"""
 
 from collections import defaultdict
+from fractions import Fraction
 
 import numpy as np
 
 from pyspinw.anisotropy import Anisotropy
+from pyspinw.cell_offsets import cell_offset_generator
 from pyspinw.exchange import Exchange
 from pyspinw.gui.edge_cases import add_extra_edge_lines, add_extra_edge_points
 from pyspinw.gui.wrap_line import split_and_wrap_line_segment
 from pyspinw.hamiltonian import Hamiltonian
 from pyspinw.site import LatticeSite
-from pyspinw.symmetry.supercell import CommensurateSupercell
+from pyspinw.symmetry.supercell import CommensurateSupercell, RotationSupercell, PropagationVector
 from pyspinw.symmetry.unitcell import UnitCell
 from pyspinw.util import rotation_from_z
 
@@ -182,12 +184,15 @@ class RenderModel:
     def __init__(self,
                  hamiltonian: Hamiltonian,
                  copies: tuple[int, int, int] = (1,1,1),
-                 rotation_supercell_expansion_max=(10,10,10)):
+                 rotation_supercell_expansion_max=(10,10,10),
+                 propagation_vector_tolerance=1e-4):
 
 
         # Deal with added scaling, and rotation supercells
+
+        # Change the scaling on the supercell if its commensurate according to `copies`
         if isinstance(hamiltonian.structure.supercell, CommensurateSupercell):
-            # Change the scaling on the supercell
+
             new_scaling = tuple(x*y for x, y in zip(copies, hamiltonian.structure.supercell.scaling))
 
             hamiltonian = hamiltonian.updated(
@@ -195,10 +200,39 @@ class RenderModel:
                     supercell = hamiltonian.structure.supercell.rescale(new_scaling)
                 ))
 
+            expansion_size = None
+
+        # If it's a rotation supercell, we want to expand it sensibly
+        elif isinstance(hamiltonian.structure.supercell, RotationSupercell):
+            # Find the periodicity of the supercell, this is a bit weird because of floating points
+            # Basic plan is to see if the vector is close to a quotient in some limited set of quotients
+            # i.e. Q_test = {a/b | a,b in N, b < n}
+            # we can find the closest one of these using Fraction.limit_denominator
+            # then, when we have the closest one, see if it is close enough
+
+
+            propagation_vector = hamiltonian.structure.supercell.propagation_vector.vector
+
+            expansion_size = [s for s in rotation_supercell_expansion_max]
+            for i in range(3):
+                closest_fraction = Fraction(propagation_vector[i])\
+                    .limit_denominator(rotation_supercell_expansion_max[i])
+
+                if abs(float(closest_fraction) - propagation_vector[i]) < propagation_vector_tolerance:
+                    expansion_size[i] = closest_fraction.denominator
+
+            expansion_size = tuple(expansion_size)
+
+
+        else:
+            raise TypeError("Expected supercell to be of type RotationSupercell or subclass of CommensurateSupercell")
+
         self.hamiltonian = hamiltonian
 
         self.expanded, site_mapping, self.exchange_mapping, self.anisotropy_mapping = \
-            self.hamiltonian._expand_with_mapping()
+            self.hamiltonian._expand_with_mapping(expansion_size)
+
+        self.expansion_size = hamiltonian.structure.supercell.cell_size() if expansion_size is None else expansion_size
 
         self.site_expanded_uid_to_original_uid: dict[int, int] = {}
         self.site_original_uid_to_expanded_uid: defaultdict[int, list[int]] = defaultdict(list)
@@ -311,3 +345,7 @@ class RenderModel:
             rotation_matrix[:3, :3] = rotation_from_z(direction)
 
             self.unit_cell_axes_transforms.append(rotation_matrix @ translation_matrix)
+
+    def cells(self):
+        return cell_offset_generator(*self.expansion_size)
+

--- a/pyspinw/gui/rendermodel.py
+++ b/pyspinw/gui/rendermodel.py
@@ -347,5 +347,6 @@ class RenderModel:
             self.unit_cell_axes_transforms.append(rotation_matrix @ translation_matrix)
 
     def cells(self):
+        """ Generator for cell offsets for each of the displayed cells"""
         return cell_offset_generator(*self.expansion_size)
 

--- a/pyspinw/gui/viewer.py
+++ b/pyspinw/gui/viewer.py
@@ -9,10 +9,10 @@ from PySide6.QtGui import QSurfaceFormat
 from imageio import imwrite
 
 from PySide6.QtCore import Qt, QDir
-from PySide6.QtWidgets import QSplitter, QWidget, QVBoxLayout, QTextEdit, QApplication, QFileDialog, QMessageBox
+from PySide6.QtWidgets import QSplitter, QWidget, QVBoxLayout, QApplication, QFileDialog, QMessageBox
 from numpy._typing import ArrayLike
 
-from pyspinw import Structure, RotationSupercell
+from pyspinw import Structure
 from pyspinw.gui.crystalview import CrystalViewerWidget
 from pyspinw.gui.icons.iconload import png_icon
 from pyspinw.gui.rendermodel import RenderModel
@@ -20,8 +20,7 @@ from pyspinw.gui.displayoptionstoolbar import DisplayOptionsToolbar
 from pyspinw.gui.displayoptions import DisplayOptions
 from pyspinw.gui.textdisplay import TextDisplay
 from pyspinw.hamiltonian import Hamiltonian
-from pyspinw.util import rotation_matrix, rotation_from_z
-from symmetry.supercell import CommensurateSupercell
+from pyspinw.util import rotation_from_z
 
 # Force desktop OpenGL before any Qt import (critical on macOS)
 os.environ.setdefault("QT_OPENGL", "desktop")
@@ -71,18 +70,6 @@ class Viewer(QWidget):
                 not all(isinstance(x, int) for x in rotation_supercell_expansion_max):
             raise ValueError("Expected `rotation_supercell_expansion_max` to be a triple of ints")
 
-        # Deal with added scaling, and rotation supercells
-        if isinstance(hamiltonian.structure.supercell, RotationSupercell):
-            pass
-
-        if isinstance(hamiltonian.structure.supercell, CommensurateSupercell):
-            # Change the scaling on the supercell
-            new_scaling = tuple(x*y for x, y in zip(copies, hamiltonian.structure.supercell.scaling))
-
-            hamiltonian = hamiltonian.updated(
-                structure = hamiltonian.structure.updated(
-                    supercell = hamiltonian.structure.supercell.rescale(new_scaling)
-                ))
 
         self.save_config_on_exit = save_config_on_exit
 
@@ -102,7 +89,7 @@ class Viewer(QWidget):
 
         self._unique_id = _generate_unique_id()
 
-        render_model = RenderModel(hamiltonian)
+        render_model = RenderModel(hamiltonian, copies, rotation_supercell_expansion_max)
 
         layout = QVBoxLayout()
 
@@ -239,7 +226,9 @@ def get_app():
 def snapshot(object: Hamiltonian | Structure,
              filename: str | None = None,
              view_point: ArrayLike = (0,0,10.0),
-             display_options: DisplayOptions | None = None):
+             display_options: DisplayOptions | None = None,
+             copies: tuple[int,int,int]=(1,1,1),
+             rotation_supercell_expansion_max: tuple[int,int,int]=(10,10,10)):
     """ Make (and display) an image of a structure/hamiltonian
 
     If filename is not a string, it will create a matplotlib plot window
@@ -276,8 +265,10 @@ def snapshot(object: Hamiltonian | Structure,
     # app.styleHints().setColorScheme(Qt.ColorScheme.Dark)
     # app.styleHints().setColorScheme(Qt.ColorScheme.Light)
 
-    viewer = Viewer(object, rotation, distance, display_options, save_config_on_exit=False)
-    viewer.setWindowTitle("Hamiltonian Viewer")
+    viewer = Viewer(object, rotation, distance, display_options,
+                    save_config_on_exit=False, copies=copies,
+                    rotation_supercell_expansion_max=rotation_supercell_expansion_max)
+
     viewer.resize(800, 600)
 
     viewer.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen, True)
@@ -312,7 +303,10 @@ def snapshot(object: Hamiltonian | Structure,
         imwrite(filename, data)
 
 
-def show_object(object: Hamiltonian | Structure, block=True):
+def show_object(object: Hamiltonian | Structure,
+                block=True,
+                copies: tuple[int,int,int]=(1,1,1),
+                rotation_supercell_expansion_max: tuple[int,int,int]=(10,10,10)):
     """ Show a Hamiltonian or structure in the viewer"""
     try:
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("org.spinw.pyspinw")
@@ -333,7 +327,7 @@ def show_object(object: Hamiltonian | Structure, block=True):
     # app.styleHints().setColorScheme(Qt.ColorScheme.Dark)
     # app.styleHints().setColorScheme(Qt.ColorScheme.Light)
 
-    viewer = Viewer(object)
+    viewer = Viewer(object, copies=copies, rotation_supercell_expansion_max=rotation_supercell_expansion_max)
     viewer.setWindowTitle("Hamiltonian Viewer")
     viewer.resize(800, 600)
     viewer.show()

--- a/pyspinw/gui/viewer.py
+++ b/pyspinw/gui/viewer.py
@@ -12,7 +12,7 @@ from PySide6.QtCore import Qt, QDir
 from PySide6.QtWidgets import QSplitter, QWidget, QVBoxLayout, QTextEdit, QApplication, QFileDialog, QMessageBox
 from numpy._typing import ArrayLike
 
-from pyspinw import Structure
+from pyspinw import Structure, RotationSupercell
 from pyspinw.gui.crystalview import CrystalViewerWidget
 from pyspinw.gui.icons.iconload import png_icon
 from pyspinw.gui.rendermodel import RenderModel
@@ -21,6 +21,7 @@ from pyspinw.gui.displayoptions import DisplayOptions
 from pyspinw.gui.textdisplay import TextDisplay
 from pyspinw.hamiltonian import Hamiltonian
 from pyspinw.util import rotation_matrix, rotation_from_z
+from symmetry.supercell import CommensurateSupercell
 
 # Force desktop OpenGL before any Qt import (critical on macOS)
 os.environ.setdefault("QT_OPENGL", "desktop")
@@ -56,9 +57,24 @@ class Viewer(QWidget):
                  initial_distance: float | None = None,
                  display_options: DisplayOptions | None = None,
                  save_config_on_exit: bool = True,
+                 copies: tuple[int, int, int] = (1, 1, 1),
+                 rotation_supercell_expansion_max: tuple[int, int, int] = (10, 10, 10),
                  parent=None):
 
         super().__init__(parent)
+
+        # Deal with added scaling, and rotation supercells
+        if isinstance(hamiltonian.structure.supercell, RotationSupercell):
+            pass
+
+        if isinstance(hamiltonian.structure.supercell, CommensurateSupercell):
+            # Change the scaling on the supercell
+            new_scaling = tuple(x*y for x, y in zip(copies, hamiltonian.structure.supercell.scaling))
+
+            hamiltonian = hamiltonian.updated(
+                structure = hamiltonian.structure.updated(
+                    supercell = hamiltonian.structure.supercell.rescale(new_scaling)
+                ))
 
         self.save_config_on_exit = save_config_on_exit
 

--- a/pyspinw/gui/viewer.py
+++ b/pyspinw/gui/viewer.py
@@ -63,6 +63,14 @@ class Viewer(QWidget):
 
         super().__init__(parent)
 
+        # Some parameter checking
+        if len(copies) != 3 and not all(isinstance(x, int) for x in copies):
+            raise ValueError("Expected `copies` to be a triple of ints")
+
+        if len(rotation_supercell_expansion_max) != 3 and \
+                not all(isinstance(x, int) for x in rotation_supercell_expansion_max):
+            raise ValueError("Expected `rotation_supercell_expansion_max` to be a triple of ints")
+
         # Deal with added scaling, and rotation supercells
         if isinstance(hamiltonian.structure.supercell, RotationSupercell):
             pass

--- a/pyspinw/gui/viewer.py
+++ b/pyspinw/gui/viewer.py
@@ -58,6 +58,7 @@ class Viewer(QWidget):
                  save_config_on_exit: bool = True,
                  copies: tuple[int, int, int] = (1, 1, 1),
                  rotation_supercell_expansion_max: tuple[int, int, int] = (10, 10, 10),
+                 propagation_vector_commensurability_tolerance=1e-4,
                  parent=None):
 
         super().__init__(parent)
@@ -89,7 +90,8 @@ class Viewer(QWidget):
 
         self._unique_id = _generate_unique_id()
 
-        render_model = RenderModel(hamiltonian, copies, rotation_supercell_expansion_max)
+        render_model = RenderModel(hamiltonian, copies, rotation_supercell_expansion_max,
+                                   propagation_vector_commensurability_tolerance)
 
         layout = QVBoxLayout()
 
@@ -228,7 +230,8 @@ def snapshot(object: Hamiltonian | Structure,
              view_point: ArrayLike = (0,0,10.0),
              display_options: DisplayOptions | None = None,
              copies: tuple[int,int,int]=(1,1,1),
-             rotation_supercell_expansion_max: tuple[int,int,int]=(10,10,10)):
+             rotation_supercell_expansion_max: tuple[int,int,int]=(10,10,10),
+             propagation_vector_commensurability_tolerance=1e-4):
     """ Make (and display) an image of a structure/hamiltonian
 
     If filename is not a string, it will create a matplotlib plot window
@@ -267,7 +270,8 @@ def snapshot(object: Hamiltonian | Structure,
 
     viewer = Viewer(object, rotation, distance, display_options,
                     save_config_on_exit=False, copies=copies,
-                    rotation_supercell_expansion_max=rotation_supercell_expansion_max)
+                    rotation_supercell_expansion_max=rotation_supercell_expansion_max,
+                    propagation_vector_commensurability_tolerance=propagation_vector_commensurability_tolerance)
 
     viewer.resize(800, 600)
 
@@ -306,7 +310,8 @@ def snapshot(object: Hamiltonian | Structure,
 def show_object(object: Hamiltonian | Structure,
                 block=True,
                 copies: tuple[int,int,int]=(1,1,1),
-                rotation_supercell_expansion_max: tuple[int,int,int]=(10,10,10)):
+                rotation_supercell_expansion_max: tuple[int,int,int]=(10,10,10),
+                propagation_vector_commensurability_tolerance=1e-4):
     """ Show a Hamiltonian or structure in the viewer"""
     try:
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("org.spinw.pyspinw")
@@ -327,7 +332,9 @@ def show_object(object: Hamiltonian | Structure,
     # app.styleHints().setColorScheme(Qt.ColorScheme.Dark)
     # app.styleHints().setColorScheme(Qt.ColorScheme.Light)
 
-    viewer = Viewer(object, copies=copies, rotation_supercell_expansion_max=rotation_supercell_expansion_max)
+    viewer = Viewer(object, copies=copies,
+                    rotation_supercell_expansion_max=rotation_supercell_expansion_max,
+                    propagation_vector_commensurability_tolerance=propagation_vector_commensurability_tolerance)
     viewer.setWindowTitle("Hamiltonian Viewer")
     viewer.resize(800, 600)
     viewer.show()

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -277,7 +277,6 @@ class Hamiltonian(SPWSerialisable):
                 dict[tuple[int, tuple[int, int, int]], LatticeSite],
                 list[int],
                 list[int]]:
-
         """ Expand the supercell structure into a single cell structure and return the mapping between hamiltonians
 
         This should only be used internally, and its not very user friendly
@@ -353,7 +352,6 @@ class Hamiltonian(SPWSerialisable):
 
     def expanded(self, supercell_size: tuple[int, int, int] | None = None):
         """ Expand the supercell structure into a single cell structure """
-
         if supercell_size is not None:
             if not isinstance(supercell_size, tuple):
                 raise TypeError("supercell_size should be a tuple")
@@ -1048,7 +1046,6 @@ class Hamiltonian(SPWSerialisable):
                 exchanges: list[Exchange] | None = None,
                 anisotropies: list[Anisotropy] | None = None):
         """ Create a new Hamiltonian, but with some fields replaced (those not None) """
-
         return Hamiltonian(
             self.structure if structure is None else structure,
             self.exchanges if exchanges is None else exchanges,

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -1,5 +1,6 @@
 """Selection of different Hamiltonians"""
 import logging
+import warnings
 from collections.abc import Callable
 import re
 from collections import Counter
@@ -18,7 +19,7 @@ from pyspinw.calculations.spinwave import (
     MagneticField as PyMagneticField)
 
 from pyspinw.anisotropy import Anisotropy
-from pyspinw.cell_offsets import CellOffset
+from pyspinw.cell_offsets import CellOffset, cell_offset_generator
 from pyspinw.checks import check_sizes
 from pyspinw.exchange import Exchange
 from pyspinw.path import Path, Slice
@@ -267,10 +268,16 @@ class Hamiltonian(SPWSerialisable):
 
         return "\n".join(lines)
 
-    def _expand_with_mapping(self) -> tuple["Hamiltonian",
-                                            dict[tuple[int, tuple[int, int, int]], LatticeSite],
-                                            list[int],
-                                            list[int]]:
+
+
+
+    def _expand_with_mapping(self, supercell_size: tuple[int, int, int] | None = None) -> \
+            tuple[
+                "Hamiltonian",
+                dict[tuple[int, tuple[int, int, int]], LatticeSite],
+                list[int],
+                list[int]]:
+
         """ Expand the supercell structure into a single cell structure and return the mapping between hamiltonians
 
         This should only be used internally, and its not very user friendly
@@ -279,17 +286,20 @@ class Hamiltonian(SPWSerialisable):
         The exchange mapping is a len(new exchanges) list of indices for the original exchanges
         The anisotropy mapping is a len(new anisotropies) list of indices for the original anisotropies
         """
-        bigger_cell, site_mapping = self.structure._expansion_site_mapping()
+        bigger_cell, site_mapping = self.structure._expansion_site_mapping(supercell_size)
 
         new_exchanges = []
         new_anisotropies = []
 
-        si, sj, sk = self.structure.supercell.cell_size()
+        if supercell_size is None:
+            si, sj, sk = self.structure.supercell.cell_size()
+        else:
+            si, sj, sk = supercell_size
 
         exchange_mapping = []
         anisotropy_mapping = []
 
-        for first_site_offset in self.structure.supercell.cells():
+        for first_site_offset in cell_offset_generator(si, sj, sk):
             for original_index, exchange in enumerate(self.exchanges):
                 # Convert the offset in the exchange, into
                 #  1) an offset in the supercell, and
@@ -341,9 +351,26 @@ class Hamiltonian(SPWSerialisable):
         return (Hamiltonian(structure=structure, exchanges=new_exchanges, anisotropies=new_anisotropies),
                 site_mapping, exchange_mapping, anisotropy_mapping)
 
-    def expanded(self):
+    def expanded(self, supercell_size: tuple[int, int, int] | None = None):
         """ Expand the supercell structure into a single cell structure """
-        expanded, _, _, _ = self._expand_with_mapping()
+
+        if supercell_size is not None:
+            if not isinstance(supercell_size, tuple):
+                raise TypeError("supercell_size should be a tuple")
+            if len(supercell_size) != 3:
+                raise TypeError("supercell_size should be a length 3 tuple")
+
+            supercell_size = tuple(int(x) for x in supercell_size)
+
+        if isinstance(self.structure.supercell, RotationSupercell):
+            if supercell_size is None:
+                logger.warning("Expanding an incommensurate structure requires a supercell_size parameter, "
+                              "or it will make a 1x1x1 supercell")
+        else:
+            if supercell_size is not None:
+                logger.warning("You are overriding the supercell size in a commensurate structure")
+
+        expanded, _, _, _ = self._expand_with_mapping(supercell_size)
         return expanded
 
     def without_nonmagnetic(self):

--- a/pyspinw/hamiltonian.py
+++ b/pyspinw/hamiltonian.py
@@ -1016,6 +1016,16 @@ class Hamiltonian(SPWSerialisable):
 
         return Hamiltonian(structure, exchanges, anisotropies)
 
+    def updated(self,
+                structure: Structure | None = None,
+                exchanges: list[Exchange] | None = None,
+                anisotropies: list[Anisotropy] | None = None):
+        """ Create a new Hamiltonian, but with some fields replaced (those not None) """
+
+        return Hamiltonian(
+            self.structure if structure is None else structure,
+            self.exchanges if exchanges is None else exchanges,
+            self.anisotropies if anisotropies is None else anisotropies)
 
     def _serialise(self, context: SPWSerialisationContext) -> dict:
         return {"magnetic_structure": self.structure._serialise(context),

--- a/pyspinw/structures.py
+++ b/pyspinw/structures.py
@@ -322,9 +322,7 @@ class Structure(SPWSerialisable):
                 unit_cell: UnitCell | None = None,
                 spacegroup: SymmetryGroup | None = None,
                 supercell: Supercell | None = None):
-
         """ Make a copy of this structure, but with selected (not None) fields replaced"""
-
         return Structure(
             self._input_sites if sites is None else sites,
             self._unit_cell if unit_cell is None else unit_cell,

--- a/pyspinw/structures.py
+++ b/pyspinw/structures.py
@@ -4,6 +4,7 @@ import re
 import numpy as np
 from ase.data import chemical_symbols
 
+from pyspinw.cell_offsets import cell_offset_generator
 from pyspinw.serialisation import SPWSerialisable
 from pyspinw.site import LatticeSite
 from pyspinw.symmetry.group import SpaceGroup, MagneticSpaceGroup, SymmetryGroup, database
@@ -149,21 +150,30 @@ class Structure(SPWSerialisable):
 
         return unique_sites
 
-    def _expansion_site_mapping(self):
+    def _expansion_site_mapping(self, supercell_size: tuple[int, int, int] | None = None):
         """ Expand supercell into a single, bigger cell """
         # Calculate new cell
-        scale = self.supercell.cell_size()
+        if supercell_size is None:
+            scale = self.supercell.cell_size()
+        else:
+            scale = supercell_size
 
         big_cell = self.unit_cell.updated(
             a=self.unit_cell.a * scale[0],
             b=self.unit_cell.b * scale[1],
             c=self.unit_cell.c * scale[2])
 
+        scaling = np.array(scale, dtype=float)
+
         # Create a mapping between sites and offsets to the new sites
         mapping: dict[tuple[int, tuple[int, int, int]], LatticeSite] = {}
-        for index, offset in enumerate(self.supercell.cells()):
+        for index, offset in enumerate(cell_offset_generator(*scale)):
             for site in self.sites:
-                position = self.supercell.fractional_in_supercell(site.ijk, offset)
+
+                position = offset.vector + np.array(site.ijk, dtype=float)
+                position /= scaling
+
+
                 spin = self.supercell.spin(site, cell_offset=offset)
 
                 new_site = LatticeSite(

--- a/pyspinw/structures.py
+++ b/pyspinw/structures.py
@@ -280,54 +280,10 @@ class Structure(SPWSerialisable):
         """ Print out details of this structure """
         print(self.text_summary)
 
-    def site_by_name(self, name):
-        """ Get a single site by its name"""
-        found = self.sites_by_name(name)
-        if len(found) == 0:
-            raise ValueError(f"No site matching '{name}' found")
-        elif len(found) > 1:
-            # Are any an exact match
-            exact_matches = [site for site in found if site.name == name]
-
-            if len(exact_matches) == 1:
-                return exact_matches[0]
-
-            raise ValueError(f"Multiple sites matching '{name}' found (multiple or no exact matches)")
-        else:
-            return found[0]
-
-    @property
-    def text_summary(self) -> str:
-        """ Textual details of this structure """
-        lines = []
-        lines.append(f"Unit Cell: {self.unit_cell.text_summary}")
-        lines.append(f"Spacegroup: {self.spacegroup.preferred_symbol}")
-        supercell_text_data = self.supercell.text_data()
-        lines.append(f"Supercell: {supercell_text_data[0]}")
-        lines += ["  " + s for s in supercell_text_data[1:]]
-        lines.append("Sites:")
-        for site in self._sites:
-
-            is_not_input_chr = "" if site.unique_id in self._input_uid_to_site else "* "
-
-            lines.append(f"  {is_not_input_chr}{site}")
-
-        return "\n".join(lines)
-
-    def print_summary(self):
-        """ Print out details of this structure """
-        print(self.text_summary)
-
     @property
     def spacegroup(self) -> SpaceGroup | MagneticSpaceGroup:
         """ Get the spacegroup"""
         return self._spacegroup
-
-    # @spacegroup.setter
-    # def spacegroup(self, spacegroup: SpaceGroup | MagneticSpaceGroup):
-    #     """ Set the spacegroup"""
-    #     self._spacegroup = spacegroup
-    #     self._build_sites()
 
     @property
     def unit_cell(self) -> UnitCell:
@@ -350,3 +306,17 @@ class Structure(SPWSerialisable):
         """ Set the supercell """
         self._supercell = supercell
         self._build_sites()
+
+    def updated(self,
+                sites: list[LatticeSite] | None = None,
+                unit_cell: UnitCell | None = None,
+                spacegroup: SymmetryGroup | None = None,
+                supercell: Supercell | None = None):
+
+        """ Make a copy of this structure, but with selected (not None) fields replaced"""
+
+        return Structure(
+            self._input_sites if sites is None else sites,
+            self._unit_cell if unit_cell is None else unit_cell,
+            self._spacegroup if spacegroup is None else spacegroup,
+            self._supercell if supercell is None else supercell)

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -337,6 +337,11 @@ class CommensurateSupercell(Supercell):
         self._propagation_vectors = propagation_vectors
         super().__init__(scaling)
 
+    @abstractmethod
+    def rescale(self, new_scaling: tuple[int, int, int]):
+        """ Create a new supercell, but with different scaling """
+
+
 
     def cell_size(self) -> tuple[int, int, int] | None:
         """ Get the smallest possible supercell"""
@@ -371,6 +376,7 @@ class TiledSupercell(CommensurateSupercell):
     supercell_name = "tiled"
 
 
+
     def spin_calculation(self, spin_data: np.ndarray, cell_offset: CellOffset):
         """ Get the spin for a given cell, and the specified spin data """
         return spin_data[0, :]
@@ -378,6 +384,10 @@ class TiledSupercell(CommensurateSupercell):
     def cell_size(self) -> tuple[int, int, int]:
         """ How big is this supercell """
         return self._scaling
+
+    def rescale(self, new_scaling: tuple[int, int, int]):
+        """ Create a copy of this supercell, but with different scaling """
+        return TiledSupercell(new_scaling)
 
     def summation_form(self) -> "Supercell":
         """ Get this supercell in summation form """
@@ -414,13 +424,19 @@ class TransformationSupercell(CommensurateSupercell):
                  transforms: list[tuple[CommensuratePropagationVector, SupercellTransformation | None]],
                  scaling=(1, 1, 1)):
 
-        # TODO: Provide a nicer interface for this maybe
+        self._input_transforms = transforms
+
         self._transforms = [(vector, IdentityTransform() if transform is None else transform)
                             for vector, transform in transforms]
 
         propagation_vectors = [vector for vector, _ in transforms]
 
         super().__init__(propagation_vectors, scaling)
+
+
+    def rescale(self, new_scaling: tuple[int, int, int]):
+        """ Create a copy of this supercell, but with different scaling """
+        return TransformationSupercell(self._input_transforms, new_scaling)
 
     def spin_calculation(self, spin_data: np.ndarray, cell_offset: CellOffset):
         """ Calculate the spin based on the spin data for a given site """
@@ -485,6 +501,12 @@ class SummationSupercell(CommensurateSupercell):
                  scaling: tuple[int, int, int] | None = None):
 
         super().__init__(propagation_vectors, scaling)
+
+
+    def rescale(self, new_scaling: tuple[int, int, int]):
+        """ Create a copy of this supercell, but with different scaling """
+        return SummationSupercell(self._propagation_vectors, new_scaling)
+
 
     def spin_calculation(self, spin_data: np.ndarray, cell_offset: CellOffset):
         """ Calculate spin at a given cell offset"""

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -11,7 +11,7 @@ from pyspinw.serialisation import SPWSerialisable, SPWSerialisationContext, \
     serialise_fraction_or_builtin, deserialise_fraction_or_builtin, SPWDeserialisationContext, expects_keys, \
     SPWSerialisationError, numpy_serialise, numpy_deserialise
 from pyspinw.site import LatticeSite
-from pyspinw.cell_offsets import CellOffset
+from pyspinw.cell_offsets import CellOffset, cell_offset_generator
 from pyspinw.util import rotation_matrix
 
 
@@ -244,11 +244,10 @@ class Supercell(ABC, SPWSerialisable):
 
     def cells(self):
         """ Iterator for cells in supercell """
+
         a, b, c = self.cell_size()
-        for i in range(a):
-            for j in range(b):
-                for k in range(c):
-                    yield CellOffset(i,j,k)
+        for cell_offset in cell_offset_generator(a,b,c):
+            yield cell_offset
 
     def wrap_sum(self, offset_1: CellOffset, *other_offsets: CellOffset):
         """ Calculate the sum of cell offsets, wrapped to the supercell, x,y,z % cell_dim"""

--- a/pyspinw/symmetry/supercell.py
+++ b/pyspinw/symmetry/supercell.py
@@ -244,7 +244,6 @@ class Supercell(ABC, SPWSerialisable):
 
     def cells(self):
         """ Iterator for cells in supercell """
-
         a, b, c = self.cell_size()
         for cell_offset in cell_offset_generator(a,b,c):
             yield cell_offset


### PR DESCRIPTION
Adds the following functionality to the viewer:

* The ability to view multiple copies of the system (i.e. build a (bigger) supercell when viewing)
* Expand out incommensurate supercells a finite amount when viewing